### PR TITLE
Remove excess comma in manifest

### DIFF
--- a/se.sjoerd.DatMan.json
+++ b/se.sjoerd.DatMan.json
@@ -31,7 +31,7 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "branch" : "main",
+                    "branch" : "main"
                 }
             ]
         }


### PR DESCRIPTION
As the last object of a JSON object, appending a comma is against the JSON specification. 