### PR TITLE
bump libadwaita requirement to 1.2

### DIFF
--- a/src/add_data_advanced.ui
+++ b/src/add_data_advanced.ui
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <requires lib="libadwaita" version="1.0" />
+  <requires lib="libadwaita" version="1.2" />
   <template class="AddAdvancedWindow" parent="AdwWindow">
     <property name="title">Open Data From File (Advanced)</property>
     <property name="default-width">650</property>

--- a/src/add_equation_window.ui
+++ b/src/add_equation_window.ui
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <requires lib="libadwaita" version="1.0" />
+  <requires lib="libadwaita" version="1.2" />
   <template class="AddEquationWindow" parent="AdwWindow">
     <property name="title">Add Equation</property>
     <property name="default-width">575</property>

--- a/src/open_special.ui
+++ b/src/open_special.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <requires lib="libadwaita" version="1.0"/>
+  <requires lib="libadwaita" version="1.2"/>
   <template class="AddEquationWindow" parent="AdwWindow">
     <property name="title">Add Equation</property>
     <property name="default-width">256</property>

--- a/src/pip_mode.ui
+++ b/src/pip_mode.ui
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <requires lib="libadwaita" version="1.0" />
+  <requires lib="libadwaita" version="1.2" />
   <template class="PIPWindow" parent="AdwWindow">
     <property name="title">Graph</property>
     <property name="default-width">800</property>

--- a/src/plot_settings.ui
+++ b/src/plot_settings.ui
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <requires lib="libadwaita" version="1.0" />
+  <requires lib="libadwaita" version="1.2" />
   <template class="PlotSettingsWindow" parent="AdwPreferencesWindow">
     <property name="can-navigate-back">True</property>
     <property name="title">Plot Settings</property>

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <requires lib="libadwaita" version="1.0" />
+  <requires lib="libadwaita" version="1.2" />
   <template class="PreferencesWindow" parent="AdwPreferencesWindow">
     <property name="can-navigate-back">True</property>
     <child>

--- a/src/rename_label_window.ui
+++ b/src/rename_label_window.ui
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <requires lib="libadwaita" version="1.0" />
+  <requires lib="libadwaita" version="1.2" />
   <template class="RenameLabelWindow" parent="AdwWindow">
     <property name="title">Rename Label</property>
     <property name="default-width">575</property>

--- a/src/sample_box.ui
+++ b/src/sample_box.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
+  <requires lib="libadwaita" version="1.2" />
   <template class="SampleBox" parent="GtkBox">
     <child>
       <object class="GtkBox" id="sample_box">

--- a/src/transform_window.ui
+++ b/src/transform_window.ui
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <interface>
   <requires lib="gtk" version="4.0" />
-  <requires lib="libadwaita" version="1.0" />
+  <requires lib="libadwaita" version="1.2" />
   <template class="TransformWindow" parent="AdwWindow">
     <property name="title">Transform Data</property>
     <property name="default-width">425</property>


### PR DESCRIPTION
Since the flatpak target is GNOME 43, which ships with libadwaita 1.2 and a few components in use are 1.1 or newer, there should be no downside to raising the requirement. Leaving it as is might lead to future errors in non-flatpak builds.