### PR TITLE
Proposal: UI changes

### DIFF
--- a/src/add_data_advanced.ui
+++ b/src/add_data_advanced.ui
@@ -34,55 +34,39 @@
             <property name="margin-top">20</property>
             <property name="margin-bottom">20</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="name">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="title" translatable="yes">Name</property>
-                <property name="subtitle" translatable="yes">The name that is to be used for the data set (single file only)</property>
-                <child>
-                  <object class="GtkEntry" id="name">
-                    <property name="placeholder-text">Leave blank to use filename</property>
-                    <property name="max-width-chars">10</property>"
-                    <property name="valign">center</property>
-                  </object>
-                </child>
+                <property name="title" translatable="yes">Name (single file only)</property>
+                <!--property name="subtitle" translatable="yes">The name that is to be used for the data set (single file only)</property!-->
+                <property name="max-width-chars">10</property>""
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="delimiter">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="title" translatable="yes">Delimiter</property>
-                <property name="subtitle" translatable="yes">The delimiter that separates the columns (\s+ for whitespace)</property>
+                <property name="title" translatable="yes">Delimiter (\s+ for whitespace)</property>
+                <!--property name="subtitle" translatable="yes">The delimiter that separates the columns (\s+ for whitespace)</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="delimiter">
-                    <property name="max-width-chars">10</property>"
-                    <property name="valign">center</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">10</property>""
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="separator">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Decimal Separator</property>
                 <property name="subtitle" translatable="yes">The character that is used as decimal separator</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="separator">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">.</item>
-                          <item translatable="yes">,</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">.</item>
+                      <item translatable="yes">,</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -19,27 +19,24 @@ def on_accept(widget, self, window):
     equation = str(window.equation_entry.get_text())
     try:
         new_file = create_data(self, x_start, x_stop, equation, step_size, str(window.name_entry.get_text()))
+        name = new_file.filename
+        if name in self.datadict:
+            if self.preferences.config["allow_duplicate_filenames"]:
+                name = datman.get_duplicate_filename(self, name)
+        else:
+            new_file.filename = name
+            new_file.xdata_clipboard = [new_file.xdata]
+            new_file.ydata_clipboard = [new_file.ydata]
+            new_file.clipboard_pos = -1
+            color = plotting_tools.get_next_color(self)
+            self.datadict[new_file.filename] = new_file
+            datman.add_sample_to_menu(self, new_file.filename, color)
+            datman.select_top_row(self)
+            plotting_tools.refresh_plot(self)
+            window.destroy()
     except Exception as e:
         exception_type = e.__class__.__name__
-        win = self.props.active_window
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type} - Unable to add data from equation, make sure the syntax is correct"))
-    name = new_file.filename
-    if name in self.datadict:
-        if self.preferences.config["allow_duplicate_filenames"]:
-            name = datman.get_duplicate_filename(self, name)
-
-    if name not in self.datadict:
-        new_file.filename = name
-        new_file.xdata_clipboard = [new_file.xdata]
-        new_file.ydata_clipboard = [new_file.ydata]
-        new_file.clipboard_pos = -1
-        color = plotting_tools.get_next_color(self)
-        self.datadict[new_file.filename] = new_file
-        datman.add_sample_to_menu(self, new_file.filename, color)
-        datman.select_top_row(self)
-
-        plotting_tools.refresh_plot(self)
-    window.destroy()
+        window.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type} - Unable to add data from equation"))
 
 def create_data(self, x_start, x_stop, equation, step_size, name):
     new_file = Data()
@@ -73,6 +70,7 @@ class AddEquationWindow(Adw.Window):
     X_start_entry = Gtk.Template.Child()
     equation_entry = Gtk.Template.Child()
     name_entry = Gtk.Template.Child()
+    toast_overlay = Gtk.Template.Child()
 
     def __init__(self, parent):
         super().__init__()

--- a/src/add_equation_window.ui
+++ b/src/add_equation_window.ui
@@ -24,69 +24,69 @@
           </object>
         </child>
         <child>
-          <object class="AdwPreferencesGroup">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="title" translatable="yes">Add Equation</property>
-            <property name="description" translatable="yes"> Here you can add data using an equation using Numpy notation. Make sure to use a capital letter for the X coordinate.</property>
-            <property name="margin-start">30</property>
-            <property name="margin-end">30</property>
-            <property name="margin-top">20</property>
-            <property name="margin-bottom">20</property>
+          <object class="AdwToastOverlay" id="toast_overlay">
             <child>
-              <object class="AdwEntryRow" id="name_entry">
+              <object class="AdwPreferencesGroup">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="title" translatable="yes">Name (blank to use equation)</property>
-                <!--property name="subtitle" translatable="yes">The name that is to be used for the data set</property!-->
-                <property name="use-underline">True</property>
-                <property name="max-width-chars">25</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="equation_entry">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="title" translatable="yes">Y =</property>
-                <!--property name="subtitle" translatable="yes">The equation that is used to generate data</property!-->
-                <property name="use-underline">True</property>
-                <property name="max-width-chars">25</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="X_start_entry">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="title" translatable="yes">X Start</property>
-                <!--property name="subtitle" translatable="yes">The starting coordinate for the X axis</property!-->
-                <property name="use-underline">True</property>
-                <property name="max-width-chars">25</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="X_stop_entry">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="title" translatable="yes">X Stop</property>
-                <!--property name="subtitle" translatable="yes">The ending coordinate for the X axis</property!-->
-                <property name="use-underline">True</property>
-                <property name="max-width-chars">25</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="step_size_entry">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="title" translatable="yes">Step Size</property>
-                <!--property name="subtitle" translatable="yes">The step size to be used</property!-->
-                <property name="use-underline">True</property>
-                <property name="max-width-chars">25</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="add_equation_confirm_button">
-                <property name="label">Confirm</property>
+                <property name="title" translatable="yes">Add Equation</property>
+                <property name="description" translatable="yes"> Here you can add data using an equation using Numpy notation. Make sure to use a capital letter for the X coordinate.</property>
+                <property name="margin-start">30</property>
+                <property name="margin-end">30</property>
                 <property name="margin-top">20</property>
+                <property name="margin-bottom">20</property>
+                <child>
+                  <object class="AdwEntryRow" id="name_entry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="title" translatable="yes">Name (blank to use equation)</property>
+                    <property name="use-underline">True</property>
+                    <property name="max-width-chars">25</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwEntryRow" id="equation_entry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="title" translatable="yes">Y =</property>
+                    <property name="use-underline">True</property>
+                    <property name="max-width-chars">25</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwEntryRow" id="X_start_entry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="title" translatable="yes">X Start</property>
+                    <property name="use-underline">True</property>
+                    <property name="max-width-chars">25</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwEntryRow" id="X_stop_entry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="title" translatable="yes">X Stop</property>
+                    <property name="use-underline">True</property>
+                    <property name="max-width-chars">25</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwEntryRow" id="step_size_entry">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="title" translatable="yes">Step Size</property>
+                    <property name="use-underline">True</property>
+                    <property name="max-width-chars">25</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="add_equation_confirm_button">
+                    <property name="label">Confirm</property>
+                    <property name="margin-top">20</property>
+                    <property name="margin-bottom">10</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/src/add_equation_window.ui
+++ b/src/add_equation_window.ui
@@ -34,88 +34,53 @@
             <property name="margin-top">20</property>
             <property name="margin-bottom">20</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="name_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="title" translatable="yes">Name</property>
-                <property name="subtitle" translatable="yes">The name that is to be used for the data set</property>
+                <property name="title" translatable="yes">Name (blank to use equation)</property>
+                <!--property name="subtitle" translatable="yes">The name that is to be used for the data set</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="name_entry">
-                    <property name="placeholder-text">Leave blank to use equation</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">25</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">25</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="equation_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Y =</property>
-                <property name="subtitle" translatable="yes">The equation that is used to generate data</property>
+                <!--property name="subtitle" translatable="yes">The equation that is used to generate data</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="equation_entry">
-                    <property name="text">X</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">25</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">25</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="X_start_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">X Start</property>
-                <property name="subtitle" translatable="yes">The starting coordinate for the X axis</property>
+                <!--property name="subtitle" translatable="yes">The starting coordinate for the X axis</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="X_start_entry">
-                    <property name="text">0</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">25</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">25</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="X_stop_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">X Stop</property>
-                <property name="subtitle" translatable="yes">The ending coordinate for the X axis</property>
+                <!--property name="subtitle" translatable="yes">The ending coordinate for the X axis</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="X_stop_entry">
-                    <property name="text">10</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">25</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">25</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="step_size_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Step Size</property>
-                <property name="subtitle" translatable="yes">The step size to be used</property>
+                <!--property name="subtitle" translatable="yes">The step size to be used</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="step_size_entry">
-                    <property name="text">0.01</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">25</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">25</property>
               </object>
             </child>
             <child>

--- a/src/plot_settings.ui
+++ b/src/plot_settings.ui
@@ -28,84 +28,61 @@
             <property name="title" translatable="yes">Data</property>
             <property name="description" translatable="yes">Choose which data set to edit, the name of the data set and the axis positions</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="datalist_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Data set ID</property>
                 <property name="subtitle" translatable="yes">The data set to be edited</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="datalist_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="name_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
-                <property name="title" translatable="yes">New Name</property>
-                <property name="subtitle" translatable="yes">The new name of this data set</property>
+                <property name="title" translatable="yes">Change Name</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="name_entry">
-                    <property name="placeholder-text">Leave blank to keep current name</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">25</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">25</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_Y_position">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Y-Axis Position</property>
                 <property name="subtitle" translatable="yes">The position of the Y-axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_Y_position">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">left</item>
-                          <item translatable="yes">right</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">left</item>
+                      <item translatable="yes">right</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_X_position">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">X-Axis Position</property>
                 <property name="subtitle" translatable="yes">The position of the X-axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_X_position">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">top</item>
-                          <item translatable="yes">bottom</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">top</item>
+                      <item translatable="yes">bottom</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>
@@ -117,53 +94,43 @@
             <property name="title" translatable="yes">Line Style</property>
             <property name="description" translatable="yes">Change properties of the line style and thickness</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="linestyle_selected">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Linestyle Selected</property>
                 <property name="subtitle" translatable="yes">The linestyle when the data set is selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="linestyle_selected">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                          <item translatable="yes">solid</item>
-                          <item translatable="yes">dotted</item>
-                          <item translatable="yes">dashed</item>
-                          <item translatable="yes">dashdot</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                      <item translatable="yes">solid</item>
+                      <item translatable="yes">dotted</item>
+                      <item translatable="yes">dashed</item>
+                      <item translatable="yes">dashdot</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="linestyle_unselected">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Linestyle Unselected</property>
                 <property name="subtitle" translatable="yes">The linestyle when the data set is not selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="linestyle_unselected">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                          <item translatable="yes">solid</item>
-                          <item translatable="yes">dotted</item>
-                          <item translatable="yes">dashed</item>
-                          <item translatable="yes">dashdot</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                      <item translatable="yes">solid</item>
+                      <item translatable="yes">dotted</item>
+                      <item translatable="yes">dashed</item>
+                      <item translatable="yes">dashdot</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -205,45 +172,35 @@
             <property name="title" translatable="yes">Markers</property>
             <property name="description" translatable="yes">Change the type and size of the markers that are used</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="selected_markers_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Selected Markers</property>
                 <property name="subtitle" translatable="yes">The markers that are used when the data set is selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="selected_markers_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="unselected_markers_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Unselected Markers</property>
                 <property name="subtitle" translatable="yes">The markers that are used when the data set is selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="unselected_markers_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -298,82 +255,44 @@
             <property name="title" translatable="yes">Plot Labels</property>
             <property name="description" translatable="yes">Settings for the plot title and labels</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_title">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Plot Title</property>
-                <property name="subtitle" translatable="yes">Title used for the plot</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_title">
-                    <property name="placeholder-text">Leave blank for no title</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_Y_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-target">True</property>
                 <property name="title" translatable="yes">Left Axis Label</property>
-                <property name="subtitle" translatable="yes">Label used for the left-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_Y_label">
-                    <property name="focus-on-click">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="can-target">True</property>
-                    <property name="text">Y value</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_X_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Bottom Axis Label</property>
-                <property name="subtitle" translatable="yes">Label used for the bottom axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_X_label">
-                    <property name="text">X value</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_right_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Right Axis Label</property>
-                <property name="subtitle" translatable="yes">Label used for the right-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_right_label">
-                    <property name="text"></property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_top_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Top Axis Label</property>
-                <property name="subtitle" translatable="yes">Label used for the top axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_top_label">
-                    <property name="text"></property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
@@ -383,6 +302,7 @@
                 <property name="title" translatable="yes">Font</property>
                 <property name="subtitle" translatable="yes">The font used in the graph</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_font_chooser</property>
                 <child>
                   <object class="GtkFontButton" id="plot_font_chooser">
                     <property name="valign">center</property>
@@ -399,91 +319,71 @@
             <property name="title" translatable="yes">Scaling</property>
             <property name="description" translatable="yes">The scaling used for each axis</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_Y_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Left Axis Scale</property>
                 <property name="subtitle" translatable="yes">Scaling used for the left-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_Y_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_X_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Bottom Axis Scale</property>
                 <property name="subtitle" translatable="yes">Scaling on the bottom axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_X_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_right_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Right Axis Scale</property>
                 <property name="subtitle" translatable="yes">Scaling used for the right-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_right_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_top_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Top Axis Scale</property>
                 <property name="subtitle" translatable="yes">Scaling used for the top axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_top_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>
@@ -495,25 +395,20 @@
             <property name="title" translatable="yes">Ticks</property>
             <property name="description" translatable="yes">Settings for the ticks that are used in the plots</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_tick_direction">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Tick Directions</property>
                 <property name="subtitle" translatable="yes">Choose to have the ticks in the plot either in or out</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_tick_direction">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">in</item>
-                          <item translatable="yes">out</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">in</item>
+                      <item translatable="yes">out</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -583,9 +478,10 @@
                 <property name="title" translatable="yes">Ticks on Left Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the left-hand axis</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_left</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_left">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_left">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -597,9 +493,10 @@
                 <property name="title" translatable="yes">Ticks on Bottom Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the bottom</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_bottom</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_bottom">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_bottom">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -611,9 +508,10 @@
                 <property name="title" translatable="yes">Ticks on Top Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the top</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_top</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_top">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_top">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -625,9 +523,10 @@
                 <property name="title" translatable="yes">Ticks on Right Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the right</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_right</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_right">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_right">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -646,31 +545,27 @@
                 <property name="title" translatable="yes">Legend</property>
                 <property name="subtitle" translatable="yes">Use a legend for the lines</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_legend_check</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_legend_check">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_legend_check">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_style">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Graph Style</property>
                 <property name="subtitle" translatable="yes">The style sheet used for the graph</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_style">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -685,4 +580,3 @@
     </child>
   </template>
 </interface>
-

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -17,40 +17,29 @@
             <property name="title" translatable="yes">Import Settings</property>
             <property name="description" translatable="yes">Settings for importing graphs</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="import_delimiter">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Delimiter</property>
-                <property name="subtitle" translatable="yes">The delimiter that separates the columns (\s+ for whitespace)</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="import_delimiter">
-                    <property name="max-width-chars">10</property>"
-                    <property name="valign">center</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">10</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="import_separator">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Decimal Separator</property>
                 <property name="subtitle" translatable="yes">The character that is used as decimal separator</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="import_separator">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">.</item>
-                          <item translatable="yes">,</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">.</item>
+                      <item translatable="yes">,</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -118,27 +107,22 @@
             <property name="title" translatable="yes">Saved Plots</property>
             <property name="description" translatable="yes">General settings for the saved graphs</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="savefig_filetype_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Default Filetype</property>
                 <property name="subtitle" translatable="yes">The default filetype of saved graphs</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="savefig_filetype_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList" id="savefig_filetype_list">
-                        <items>
-                          <item translatable="yes">png</item>
-                          <item translatable="yes">ps</item>
-                          <item translatable="yes">pdf</item>
-                          <item translatable="yes">svg</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList" id="savefig_filetype_list">
+                    <items>
+                      <item translatable="yes">png</item>
+                      <item translatable="yes">ps</item>
+                      <item translatable="yes">pdf</item>
+                      <item translatable="yes">svg</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -148,9 +132,10 @@
                 <property name="title" translatable="yes">Transparent Background</property>
                 <property name="subtitle" translatable="yes">Use a transparent background for the saved plots</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">savefig_transparent_check_button</property>
                 <child>
-                  <object class="GtkCheckButton" id="savefig_transparent_check_button">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="savefig_transparent_check_button">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -164,25 +149,20 @@
             <property name="title" translatable="yes">Action Behaviour</property>
             <property name="description" translatable="yes">Preset behaviour of specific actions</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="center_data_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Center Data</property>
                 <property name="subtitle" translatable="yes">The default behaviour of the center data button</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="center_data_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">Center at maximum Y value</item>
-                          <item translatable="yes">Center at middle coordinate</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">Center at maximum Y value</item>
+                      <item translatable="yes">Center at middle coordinate</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>
@@ -195,83 +175,42 @@
             <property name="title" translatable="yes">Add Equation</property>
             <property name="description" translatable="yes">Settings for the "Add Equation" option</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="addequation_equation">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Y =</property>
-                <property name="subtitle" translatable="yes">The equation that is used to generate data</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="addequation_equation">
-                    <property name="text">X</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">20</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">20</property>
               </object>
             </child>            
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="addequation_X_start">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-target">True</property>
                 <property name="title" translatable="yes">X start</property>
-                <property name="subtitle" translatable="yes">The default value for the minimum X value</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="addequation_X_start">
-                    <property name="focus-on-click">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="can-target">True</property>
-                    <property name="text">0</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">20</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">20</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="addequation_X_stop">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-target">True</property>
                 <property name="title" translatable="yes">X stop</property>
-                <property name="subtitle" translatable="yes">The default value for the maximum X value</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="addequation_X_stop">
-                    <property name="focus-on-click">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="can-target">True</property>
-                    <property name="text">10</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">20</property>
-                    <property name="width-request">15</property>"
-                  </object>
-                </child>
+                <property name="max-width-chars">20</property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="addequation_step_size">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-target">True</property>
                 <property name="title" translatable="yes">Step Size</property>
-                <property name="subtitle" translatable="yes">The default step size</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="addequation_step_size">
-                    <property name="focus-on-click">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="can-target">True</property>
-                    <property name="text">0.01</property>
-                    <property name="valign">center</property>
-                    <property name="max-width-chars">20</property>
-                    <property name="width-request">15</property>
-                  </object>
-                </child>
+                <property name="max-width-chars">20</property>
               </object>
             </child>"                        
           </object>
@@ -289,9 +228,10 @@
                 <property name="title" translatable="yes">Allow Duplicate Filenames</property>
                 <property name="subtitle" translatable="yes">Allow duplicate filenames to be loaded</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">allow_duplicates_button</property>
                 <child>
-                  <object class="GtkCheckButton" id="allow_duplicates_button">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="allow_duplicates_button">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -311,86 +251,45 @@
             <property name="title" translatable="yes">Plot Labels</property>
             <property name="description" translatable="yes">Set the labels and titels for the axis</property>"
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_title">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Plot Title</property>
-                <property name="subtitle" translatable="yes">The default title used for the plot</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_title">
-                   <property name="placeholder-text">Leave blank for no title</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_Y_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-target">True</property>
                 <property name="title" translatable="yes">Left Axis label</property>
-                <property name="subtitle" translatable="yes">The default label used for the left-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_Y_label">
-                    <property name="focus-on-click">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="can-target">True</property>
-                    <property name="text">Y value</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_X_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Bottom Axis Label</property>
-                <property name="subtitle" translatable="yes">The default label used for the bottom axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_X_label">
-                    <property name="text">X value</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_right_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="can-target">True</property>
                 <property name="title" translatable="yes">Right Axis label</property>
-                <property name="subtitle" translatable="yes">The default label used for the right-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_right_label">
-                    <property name="focus-on-click">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="can-target">True</property>
-                    <property name="text">Y value</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="plot_top_label">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Top Axis Label</property>
-                <property name="subtitle" translatable="yes">The default label used for the top axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="plot_top_label">
-                    <property name="text"></property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
@@ -398,8 +297,8 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Font</property>
-                <property name="subtitle" translatable="yes">The default font used in the graph</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_font_chooser</property>
                 <child>
                   <object class="GtkFontButton" id="plot_font_chooser">
                     <property name="valign">center</property>
@@ -416,135 +315,105 @@
             <property name="title" translatable="yes">Aees settings</property>
             <property name="description" translatable="yes">Set the axes scale and position</property>
              <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_Y_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Left Axis Scale</property>
                 <property name="subtitle" translatable="yes">The default scaling on the left-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_Y_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_X_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Bottom Axis Scale</property>
                 <property name="subtitle" translatable="yes">The default scaling on the bottom axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_X_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
              <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_right_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Right Axis Scale</property>
                 <property name="subtitle" translatable="yes">The default scaling on the right-hand axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_right_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
              <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_top_scale">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Top Axis Scale</property>
                 <property name="subtitle" translatable="yes">The default scaling on the top axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_top_scale">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">log</item>
-                          <item translatable="yes">linear</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">log</item>
+                      <item translatable="yes">linear</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_Y_position">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Y-Axis Position</property>
                 <property name="subtitle" translatable="yes">The default position of the Y-axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_Y_position">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">left</item>
-                          <item translatable="yes">right</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">top</item>
+                      <item translatable="yes">bottom</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_X_position">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">X-Axis Position</property>
                 <property name="subtitle" translatable="yes">The default position of the X-axis</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_X_position">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">top</item>
-                          <item translatable="yes">bottom</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">top</item>
+                      <item translatable="yes">bottom</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>
@@ -556,53 +425,43 @@
             <property name="title" translatable="yes">Line Style</property>
             <property name="description" translatable="yes">Settings for the lines used in the plots</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_selected_linestyle_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Selected Linestyle</property>
                 <property name="subtitle" translatable="yes">The width of the lines that are selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_selected_linestyle_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                          <item translatable="yes">solid</item>
-                          <item translatable="yes">dotted</item>
-                          <item translatable="yes">dashed</item>
-                          <item translatable="yes">dashdot</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                      <item translatable="yes">solid</item>
+                      <item translatable="yes">dotted</item>
+                      <item translatable="yes">dashed</item>
+                      <item translatable="yes">dashdot</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_unselected_linestyle_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Unselected Linestyle</property>
                 <property name="subtitle" translatable="yes">The width of the lines that are not selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_unselected_linestyle_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                          <item translatable="yes">solid</item>
-                          <item translatable="yes">dotted</item>
-                          <item translatable="yes">dashed</item>
-                          <item translatable="yes">dashdot</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                      <item translatable="yes">solid</item>
+                      <item translatable="yes">dotted</item>
+                      <item translatable="yes">dashed</item>
+                      <item translatable="yes">dashdot</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -644,45 +503,35 @@
             <property name="title" translatable="yes">Markers</property>
             <property name="description" translatable="yes">Settings for the markers used in the plot</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_selected_markers_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Selected Markers</property>
                 <property name="subtitle" translatable="yes">The markers used for lines that are selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_selected_markers_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_unselected_markers_chooser">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Unselected Markers</property>
                 <property name="subtitle" translatable="yes">The markers used for lines that are not selected</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_unselected_markers_chooser">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">none</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">none</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -724,25 +573,20 @@
             <property name="title" translatable="yes">Ticks</property>
             <property name="description" translatable="yes">Settings for the ticks that are used in the plots</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_tick_direction">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Tick Directions</property>
                 <property name="subtitle" translatable="yes">Choose to have the ticks either in or out</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_tick_direction">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                          <item translatable="yes">in</item>
-                          <item translatable="yes">out</item>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">in</item>
+                      <item translatable="yes">out</item>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -812,9 +656,10 @@
                 <property name="title" translatable="yes">Ticks on Left Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the left-hand axis</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_left</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_left">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_left">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -826,9 +671,10 @@
                 <property name="title" translatable="yes">Ticks on Bottom Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the bottom</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_bottom</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_bottom">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_bottom">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -840,9 +686,10 @@
                 <property name="title" translatable="yes">Ticks on Top Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the top</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_top</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_top">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_top">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -854,9 +701,10 @@
                 <property name="title" translatable="yes">Ticks on Right Axis</property>
                 <property name="subtitle" translatable="yes">Show ticks on the right</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_tick_right</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_tick_right">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_tick_right">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
@@ -875,31 +723,27 @@
                 <property name="title" translatable="yes">Legend</property>
                 <property name="subtitle" translatable="yes">Use a legend for the lines</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_legend_check</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_legend_check">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_legend_check">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_color_cycle">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Color Cycle</property>
                 <property name="subtitle" translatable="yes">The default color cycle set that is used while plotting new data</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_color_cycle">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
@@ -909,51 +753,42 @@
                 <property name="title" translatable="yes">Invert Color Cycle in Dark Mode</property>
                 <property name="subtitle" translatable="yes">Use inverted colors for the color cycle used in dark mode</property>
                 <property name="use-underline">True</property>
+                <property name="activatable-widget">plot_invert_color_cycle_dark</property>
                 <child>
-                  <object class="GtkCheckButton" id="plot_invert_color_cycle_dark">
-                    <property name="halign">end</property>
+                  <object class="GtkSwitch" id="plot_invert_color_cycle_dark">
+                    <property name="valign">center</property>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_style_light">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Graph Style Light</property>
                 <property name="subtitle" translatable="yes">The style sheet used for the graph in light mode</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_style_light">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwComboRow" id="plot_style_dark">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="title" translatable="yes">Graph Style Dark</property>
                 <property name="subtitle" translatable="yes">The style used for the graph in dark mode</property>
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkDropDown" id="plot_style_dark">
-                    <property name="valign">center</property>
-                    <property name="model">
-                      <object class="GtkStringList">
-                        <items>
-                        </items>
-                      </object>
-                    </property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                    </items>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>

--- a/src/preferences.ui
+++ b/src/preferences.ui
@@ -392,8 +392,8 @@
                 <property name="model">
                   <object class="GtkStringList">
                     <items>
-                      <item translatable="yes">top</item>
-                      <item translatable="yes">bottom</item>
+                      <item translatable="yes">left</item>
+                      <item translatable="yes">right</item>
                     </items>
                   </object>
                 </property>
@@ -809,5 +809,3 @@
     </object>
   </template>
 </interface>
-
-

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -7,8 +7,9 @@ def open_transform_window(widget, _, self):
     win.set_transient_for(self.props.active_window)
     win.set_modal(True)
     button = win.transform_confirm_button
-    button.set_sensitive(True)
     button.connect("clicked", on_accept, self, win)
+    win.transform_x_entry.set_text("X")
+    win.transform_y_entry.set_text("Y")
     win.present()
     pass
 

--- a/src/transform_window.ui
+++ b/src/transform_window.ui
@@ -38,39 +38,28 @@ To convert a value from degrees into radians use radians(value), e.g. Y = sin(ra
             <property name="margin-top">20</property>
             <property name="margin-bottom">20</property>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="transform_x_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">X =</property>
-                <property name="subtitle" translatable="yes">The transformation on the X-axis</property>
+                <!--property name="subtitle" translatable="yes">The transformation on the X-axis</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="transform_x_entry">
-                    <property name="text">X</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
-              <object class="AdwActionRow">
+              <object class="AdwEntryRow" id="transform_y_entry">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="title" translatable="yes">Y =</property>
-                <property name="subtitle" translatable="yes">The transformation on the Y-axis</property>
+                <!--property name="subtitle" translatable="yes">The transformation on the Y-axis</property!-->
                 <property name="use-underline">True</property>
-                <child>
-                  <object class="GtkEntry" id="transform_y_entry">
-                    <property name="text">Y</property>
-                    <property name="valign">center</property>
-                  </object>
-                </child>
               </object>
             </child>
             <child>
               <object class="GtkButton" id="transform_confirm_button">
                 <property name="label">Confirm</property>
                 <property name="margin-top">20</property>
+                <property name="sensitive">True</property>
               </object>
             </child>
           </object>

--- a/src/window.ui
+++ b/src/window.ui
@@ -27,13 +27,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkButton" id="save_data_button">
-                        <property name="label">Save</property>
-                        <property name="action-name">app.save_data</property>
-                        <property name="tooltip-text" translatable="yes">Save the data to your device</property>
-                      </object>
-                    </child>
-                    <child>
                       <object class="GtkButton" id="undo_button">
                         <property name="action-name">app.undo</property>
                         <property name="focusable">1</property>
@@ -55,13 +48,20 @@
                 </child>
               </object>
             </child>
-            <child type="end">
+                        <child type="end">
               <object class="GtkMenuButton">
                 <property name="tooltip-text" translatable="yes">Open Application Menu</property>
                 <property name="icon-name">open-menu-symbolic</property>
                 <property name="menu-model">primary_menu</property>
               </object>
             </child>
+                                                    <child type="end">
+                      <object class="GtkButton" id="save_data_button">
+                        <property name="label">Save</property>
+                        <property name="action-name">app.save_data</property>
+                        <property name="tooltip-text" translatable="yes">Save the data to your device</property>
+                      </object>
+                    </child>>>
           </object>
         </child>
         <child>
@@ -448,4 +448,3 @@
     </section>
   </menu>
 </interface>
-

--- a/src/window.ui
+++ b/src/window.ui
@@ -150,6 +150,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Select a span of data</property>
+                                    <property name="activatable-widget">select_data_button</property>
                                     <child>
                                       <object class="GtkToggleButton" id="select_data_button">
                                         <property name="label">Select</property>"
@@ -163,6 +164,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Cut the selected span</property>
+                                    <property name="activatable-widget">cut_data_button</property>
                                     <child>
                                       <object class="GtkToggleButton" id="cut_data_button">
                                         <property name="label">Cut</property>
@@ -180,6 +182,7 @@
                                 <property name="title">Adjust Data</property>
                                 <child>
                                   <object class="AdwActionRow">
+                                    <property name="activatable-widget">normalize_button</property>
                                     <property name="subtitle">Normalize data</property>
                                     <child>
                                       <object class="GtkButton" id="normalize_button">
@@ -194,6 +197,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Shift all data vertically with respect to each other</property>
+                                    <property name="activatable-widget">shift_vertically_button</property>
                                     <child>
                                       <object class="GtkButton" id="shift_vertically_button">
                                         <property name="label">Shift</property>
@@ -207,6 +211,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Smoothen the data</property>
+                                    <property name="activatable-widget">smooth_button</property>
                                     <child>
                                       <object class="GtkButton" id="smooth_button">
                                         <property name="label">Smoothen</property>
@@ -220,6 +225,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Center the data</property>
+                                    <property name="activatable-widget">center_data_button</property>
                                     <child>
                                       <object class="GtkButton" id="center_data_button">
                                         <property name="label">Center</property>
@@ -299,6 +305,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Get Derivative of the data</property>
+                                    <property name="activatable-widget">derivative_button</property>
                                     <child>
                                       <object class="GtkButton" id="derivative_button">
                                         <property name="label">Get</property>
@@ -312,6 +319,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Get the indefinite Integral of the data</property>
+                                    <property name="activatable-widget">integral_button</property>
                                     <child>
                                       <object class="GtkButton" id="integral_button">
                                         <property name="label">Get</property>
@@ -325,6 +333,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Get the Fast Fourier Transform of the data</property>
+                                    <property name="activatable-widget">fourier_button</property>
                                     <child>
                                       <object class="GtkButton" id="fourier_button">
                                         <property name="label">Get</property>
@@ -338,6 +347,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Get the Inverse Fast Fourier Transform of the data</property>
+                                    <property name="activatable-widget">inverse_fourier_button</property>
                                     <child>
                                       <object class="GtkButton" id="inverse_fourier_button">
                                         <property name="label">Get</property>
@@ -351,6 +361,7 @@
                                 <child>
                                   <object class="AdwActionRow">
                                     <property name="subtitle">Perform custom transformations on the data</property>
+                                    <property name="activatable-widget">transform_data_button</property>
                                     <child>
                                       <object class="GtkButton" id="transform_data_button">
                                         <property name="label">Transform</property>


### PR DESCRIPTION
- Use AdwComboRows instead of AdwActionRows with a child
- Use AdwEntryRows
  - Open for suggestions as this removes the ability to add subtitles. However existing subtitles were pretty self-explanitory.
- Use GtkSwitch instead of GtkCheckBox to better fit into other apps, as CheckBoxes are used for a pick-between-options selection. In this case they toggle one option separate from the others.
- Make AdwActionRows activate their respective widget (except sliders)
- Move Toast regarding invalid equation into the popup window itself

Planned:

- [✔️  ] Settings
- [✔️ ] Add from Equation Window
- [✔️ ] Add from Data advanced Window
- [✔️ ] Transform Window

This broadens the surface area of each option, not requiring aiming on a small widget
![grafik](https://user-images.githubusercontent.com/59118042/213864814-06f7457a-5fdb-4d61-9613-9ae30bf0499b.png)
![grafik](https://user-images.githubusercontent.com/59118042/213864823-e94da9e1-228e-4886-aad9-7d75b69b7073.png)
![grafik](https://user-images.githubusercontent.com/59118042/213868965-fbdb3b75-4753-431e-b64b-87f75f9b933c.png)



