### PR TITLE
Remove apply button in plot settings, save changes directly upon notify instead

### DIFF
--- a/data/ui/plot_settings.ui
+++ b/data/ui/plot_settings.ui
@@ -234,12 +234,6 @@
                 </child>
               </object>
             </child>
-            <child>
-              <object class="GtkButton" id="apply_button">
-                <property name="label">Apply</property>
-                <property name="margin-top">20</property>
-              </object>
-            </child>
           </object>
         </child>
       </object>
@@ -569,12 +563,6 @@
                 </property>
               </object>
             </child>
-            <child>
-              <object class="GtkButton" id="apply_button_2">
-                <property name="label">Apply</property>
-                <property name="margin-top">20</property>
-              </object>
-            </child>"
           </object>
         </child>"
       </object>"


### PR DESCRIPTION
Removes apply button from plot settings, and saves changes directly upon notify (so when a new dataset is selected) or when the plot settings are closed

Fixes issue #52 