### PR TITLE
Fix stuck rows

### DIFF
--- a/src/graphs.py
+++ b/src/graphs.py
@@ -209,7 +209,7 @@ def add_sample_to_menu(self, filename, color, id, select_item = False):
     win = self.props.active_window
     self.list_box = win.list_box
     row = samplerow.SampleBox(self, filename, id)
-    row.gesture.connect("pressed", row.clicked, self)
+    row.gesture.connect("released", row.clicked, self)
     row.color_picker = colorpicker.ColorPicker(color, row=row, parent=self)
     row.color_picker.set_hexpand(False)
     label = row.sample_ID_label

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -78,7 +78,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         if set(filenames) != set(self.get_chooser_list(self.datalist_chooser)):
             utilities.populate_chooser(self.datalist_chooser, filenames)
         self.datalist_chooser.set_selected(index)
-        self.load_config(parent)
+        self.load_config(parent, id = None)
         self.chooser_changed = False
 
     def load_config(self, parent, id):
@@ -193,7 +193,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
     def save_settings(self, parent):
         item = self.item
         new_item = self.set_config(item, parent)
-        max_length = int(28)
+        max_length = int(26)
         if len(new_item.filename) > max_length:
             label = f"{new_item.filename[:max_length]}..."
         else:

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -21,6 +21,7 @@ class SampleBox(Gtk.Box):
         self.one_click_trigger = False
         self.time_first_click  = 0        
         self.gesture = Gtk.GestureClick()
+        self.gesture.set_button(0)
         self.add_controller(self.gesture)
 
     def rgba_to_tuple(rgba):
@@ -41,5 +42,4 @@ class SampleBox(Gtk.Box):
                 self.time_first_click = 0 
                 double_click = True
                 plot_settings.open_plot_settings(None, None, graphs, self.id)
-                print("You double clicked")
-        pass
+                


### PR DESCRIPTION
This fixes a the bug where the rows get stuck in an active state on double click.

This is a known upstream GTK issue where rows can get stuck upon a double click action. I'm not completely sure where the problem lies, but it gets triggered when you double click an item and immediate pop over a modal window. I believe it has something to do with the window getting triggered on click, while the fade back to the non-active state for the row gets triggered upon release. But due to this modal window freezing the UI in the parent window, this release state is never triggered.

The workaround was to just trigger the modal window upon double release instead of double click. Where I had to use another workaround to emmit a release signal on GtkGesture. See bug report [there](https://gitlab.gnome.org/GNOME/gtk/-/issues/4939). Either way, this feature works perfectly now. But just wanted to merge it with a PR instead of comitting straight to main.


See video, double click actives plot setting menu for the data set that is clicked on. Streamlining many workflows significantly. Single click does nothing.

[Screencast from 2023-02-01 09-37-52.webm](https://user-images.githubusercontent.com/68477016/215992384-9fa104d2-60ac-49f8-a9a7-0ff82113f2da.webm)
