### PR TITLE
change mode switching logic

### DIFF
--- a/src/graphs.py
+++ b/src/graphs.py
@@ -25,8 +25,6 @@ def get_theme_color(self):
 def open_selection(self, files, from_dictionary = False, import_settings = None, canvas = None):
     if canvas == None:
         canvas = self.canvas
-    if self.highlight is not None:
-        plotting_tools.define_highlight(self)
     if from_dictionary:
         for key, item in self.datadict.items():
             if item is not None:
@@ -323,7 +321,6 @@ def on_open_response(dialog, response, self, import_settings):
             import_settings["mode"] = "single"
 
         open_selection(self, files, import_settings = import_settings)
-        plotting_tools.define_highlight(self)
         win = self.props.active_window
         button = win.select_data_button
         if not button.get_active():

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -170,7 +170,6 @@ def cut_data(widget, _, self):
                     item.ydata = new_y
             delete_selected_data(self)
             add_to_clipboard(self)
-            plotting_tools.define_highlight(self)
             plotting_tools.refresh_plot(self, set_limits = False)
 
 def select_data(self):

--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,7 @@ class GraphsApplication(Adw.Application):
         self.create_action('select_none', graphs.select_none, ['<primary><shift>A'], self)
         self.create_action('transform_data', transform_data.open_transform_window, None, self)
         self.create_action('add_equation', add_equation.open_add_equation_window, ['<primary>E'], self)
-        self.create_action('select_data_toggle', plotting_tools.toggle_highlight, None, self)
+        self.create_action('select_data_toggle', plotting_tools.select, None, self)
         self.create_action('get_derivative', item_operations.get_derivative, None, self)
         self.create_action('get_integral', item_operations.get_integral, None, self)
         self.create_action('get_fourier', item_operations.get_fourier, None, self)

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 from matplotlib import colors
 from matplotlib.backends.backend_gtk4agg import (
     FigureCanvasGTK4Agg as FigureCanvas)
+from matplotlib.backend_bases import _Mode
 from . import graphs, utilities, rename_label, toolbar
 from matplotlib.widgets import SpanSelector
 from cycler import cycler
@@ -18,9 +19,6 @@ def define_highlight(self, span=None):
     Create a span selector object, to highlight part of the graph.
     If a span already exists, make it visible instead
     """
-    if (not self.highlight == None):
-        self.highlight.set_visible(False)
-        self.highlight.set_active(False)
     #This lamdba function is not pretty, but it doesn't accept a "Pass"
     self.highlight = SpanSelector(
         self.canvas.top_right_axis,
@@ -33,15 +31,13 @@ def define_highlight(self, span=None):
         drag_from_anywhere=True)
     if span is not None:
         self.highlight.extents = span
-        self.highlight.set_visible(True)
-        self.highlight.set_active(True)
 
-def toggle_highlight(shortcut, _, self):
+def select(shortcut, _, self):
     """
     Toggle the SpanSelector. 
     """
     if self.main_window.select_data_button.get_active():
-        set_mode(self, "")
+        set_mode(self, "none")
     else:
         set_mode(self, "select/cut")
 
@@ -189,9 +185,13 @@ def reload_plot(self, from_dictionary = True):
     win = self.props.active_window
     graphs.load_empty(self)
     if len(self.datadict) > 0:
-        define_highlight(self)
         hide_unused_axes(self, self.canvas)
         graphs.open_selection(self, None, from_dictionary)
+        if (not self.highlight == None):
+            self.highlight.set_visible(False)
+            self.highlight.set_active(False)
+            self.highlight = None
+        set_mode(self, self._mode)
         set_canvas_limits_axis(self, self.canvas)
     self.canvas.grab_focus()
 
@@ -375,26 +375,24 @@ def set_mode(self, mode):
     if self.highlight == None:
         define_highlight(self)
     highlight = self.highlight
-    if(mode == ""):
-        toolbar_mode = self.dummy_toolbar.mode
-        if(toolbar_mode == "pan/zoom"):
-            self.dummy_toolbar.pan()
-        elif(toolbar_mode == "zoom rect"):
-            self.dummy_toolbar.zoom()
+    if(mode == "none"):
+        self.dummy_toolbar.mode = _Mode.NONE
         pan_button.set_active(False)
         zoom_button.set_active(False)
         select_button.set_active(False)
         cut_button.set_visible(False)
         highlight.set_visible(False)
         highlight.set_active(False)
-    elif(mode == "pan/zoom"):
+    elif(mode == "pan"):
+        self.dummy_toolbar.mode = _Mode.PAN
         pan_button.set_active(True)
         zoom_button.set_active(False)
         select_button.set_active(False)
         cut_button.set_visible(False)
         highlight.set_visible(False)
         highlight.set_active(False)
-    elif(mode == "zoom rect"):
+    elif(mode == "zoom"):
+        self.dummy_toolbar.mode = _Mode.ZOOM
         pan_button.set_active(False)
         zoom_button.set_active(True)
         select_button.set_active(False)
@@ -402,17 +400,16 @@ def set_mode(self, mode):
         highlight.set_visible(False)
         highlight.set_active(False)
     elif(mode == "select/cut"):
-        toolbar_mode = self.dummy_toolbar.mode
-        if(toolbar_mode == "pan/zoom"):
-            self.dummy_toolbar.pan()
-        elif(toolbar_mode == "zoom rect"):
-            self.dummy_toolbar.zoom()
+        self.dummy_toolbar.mode = _Mode.NONE
         pan_button.set_active(False)
         zoom_button.set_active(False)
         select_button.set_active(True)
         cut_button.set_visible(True)
         highlight.set_visible(True)
         highlight.set_active(True)
+    for axis in self.canvas.figure.get_axes():
+            axis.set_navigate_mode(self.dummy_toolbar.mode._navigate_mode)
+    self._mode = mode
     self.canvas.draw()
 
 # https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L306

--- a/src/toolbar.py
+++ b/src/toolbar.py
@@ -2,8 +2,10 @@
 from . import plotting_tools
 
 def pan(widget, shortcut, self):
-    self.dummy_toolbar.pan()
-    plotting_tools.set_mode(self, self.dummy_toolbar.mode)
+    if(self.main_window.pan_button.get_active()):
+        plotting_tools.set_mode(self, "none")
+    else:
+        plotting_tools.set_mode(self, "pan")
 
 def view_back(widget, shortcut, self):
     self.dummy_toolbar._nav_stack.back()
@@ -14,7 +16,9 @@ def view_forward(widget, shortcut, self):
     self.dummy_toolbar._update_view()
 
 def zoom(widget, shortcut, self):
-    self.dummy_toolbar.zoom()
-    plotting_tools.set_mode(self, self.dummy_toolbar.mode)
+    if(self.main_window.zoom_button.get_active()):
+        plotting_tools.set_mode(self, "none")
+    else:
+        plotting_tools.set_mode(self, "zoom")
 
 


### PR DESCRIPTION
Switching modes and everything related to that is now handled by plotting_tools.set_mode().
We no longer simulate button presses on the dummy_toolbar but rely on functions deeper down the stack.
Thanks to this, mode switching is now a tad bit faster and reliable. 
Selecting a mode persists through graph.reload as well now.