### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+name: CI
+jobs:
+  flatpak:
+    name: "build-packages"
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-43
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+      with:
+        bundle: graphs.flatpak
+        manifest-path: se.sjoerd.Graphs.json
+        cache-key: flatpak-builder-${{ github.sha }}


### PR DESCRIPTION
Basic CI workflow, that simply builds Graphs into a flatpak ref, could be expanded for tools like linting and security analysis in the future.
Triggers on commits to main and pull requests