### PR TITLE
Switch to cairo backend for figurecanvas

### DIFF
--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 
 from gi.repository import Gtk, Adw
 from matplotlib import colors
-from matplotlib.backends.backend_gtk4agg import FigureCanvasGTK4Agg as FigureCanvas
+from matplotlib.backends.backend_gtk4cairo import FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.widgets import SpanSelector
 from cycler import cycler
@@ -645,4 +645,3 @@ class PlotWidget(FigureCanvas):
             rename_label.open_rename_label_window(self.parent, self.left_label)
         if self.right_label.contains(event)[0] and double_click:
             rename_label.open_rename_label_window(self.parent, self.right_label)
-


### PR DESCRIPTION
Fixes issue #89. Seems this is an upstream issue in the regular gtk4 backend, but it works fine for cairo.
No extra imports or packages are needed, Cairo needs requires [PyGObject](https://wiki.gnome.org/action/show/Projects/PyGObject) and [pycairo](https://www.cairographics.org/pycairo/) but it seems both are included in the standard runtimes (PyGObject obviously is, but I wasn't sure about pycairo before).
[Screencast from 2023-02-08 11-59-30.webm](https://user-images.githubusercontent.com/68477016/217512278-5cd9ef9e-8d3d-4b7b-8dc2-0d47ccfaaf17.webm)

Closes issue #89