### PR TITLE
implement own rubberband zoom

### DIFF
--- a/src/graphs.py
+++ b/src/graphs.py
@@ -6,10 +6,10 @@ import numpy
 import pickle
 
 from gi.repository import Gtk, Adw
-from matplotlib.backends.backend_gtk4 import NavigationToolbar2GTK4 as NavigationToolbar
 from . import plotting_tools, samplerow, colorpicker, utilities
 from .plotting_tools import PlotWidget
 from .data import Data
+from .utilities import DummyToolbar
 
 def get_theme_color(self):
     win = self.props.active_window
@@ -412,7 +412,7 @@ def load_empty(self):
     for axis in [self.canvas.right_axis, self.canvas.top_left_axis, self.canvas.top_right_axis]:
         axis.get_xaxis().set_visible(False)
         axis.get_yaxis().set_visible(False)    
-    self.dummy_toolbar = NavigationToolbar(self.canvas)
+    self.dummy_toolbar = DummyToolbar(self.canvas)
     win.toast_overlay.set_child(self.canvas)
 
 def disable_clipboard_buttons(self):

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -494,7 +494,7 @@ class PlotWidget(FigureCanvas):
     """
     Create the widget that contains the graph itself
     """
-    def __init__(self, parent=None, xlabel="", ylabel="", yscale = "log", title="", scale="linear", style = "seaborn-whitegrid"):
+    def __init__(self, parent=None, xlabel="", ylabel="", yscale = "log", title="", scale="linear", style = "adwaita"):
         self.figure = Figure()
         self.figure.set_tight_layout(True)
         self.canvas = FigureCanvas(self.figure)
@@ -507,12 +507,6 @@ class PlotWidget(FigureCanvas):
         self.right_axis = self.ax.twinx()
         self.top_left_axis = self.ax.twiny()
         self.top_right_axis = self.top_left_axis.twinx()
-
-        #Set the coordinates in the bottom-right corner as an empty string
-        #These only work for the top-right axis anyway, so is broken in 95% of
-        #the cases, and makes the experience very bad for small window sizes.
-        #This feature should be implemented differently perhaps.
-        self.top_right_axis.format_coord = lambda x, y: ""
         self.set_ax_properties(parent)
         self.set_save_properties(parent)
         self.set_color_cycle(parent)
@@ -645,3 +639,29 @@ class PlotWidget(FigureCanvas):
             rename_label.open_rename_label_window(self.parent, self.left_label)
         if self.right_label.contains(event)[0] and double_click:
             rename_label.open_rename_label_window(self.parent, self.right_label)
+
+    def _post_draw(self, widget, context):
+        """
+        Override with custom implementation of rubberband to allow for custom rubberband style
+        @param context: https://pycairo.readthedocs.io/en/latest/reference/context.html
+        """
+        if self._rubberband_rect is None:
+            return
+
+        lw = 1.5
+        if not self._context_is_scaled:
+            x0, y0, w, h = (dim / self.device_pixel_ratio
+                            for dim in self._rubberband_rect)
+        else:
+            x0, y0, w, h = self._rubberband_rect
+            lw *= self.device_pixel_ratio
+        x1 = x0 + w
+        y1 = y0 + h
+
+        context.set_antialias(1)
+        context.set_line_width(lw)
+        context.rectangle(x0, y0, w, h)
+        #input are floats so divide rgb value by 255
+        context.set_source_rgba(120 / 255, 174 / 255, 237 / 255, 1)
+        context.stroke()
+

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -648,7 +648,7 @@ class PlotWidget(FigureCanvas):
         if self._rubberband_rect is None:
             return
 
-        lw = 1.5
+        lw = 1
         if not self._context_is_scaled:
             x0, y0, w, h = (dim / self.device_pixel_ratio
                             for dim in self._rubberband_rect)
@@ -660,8 +660,11 @@ class PlotWidget(FigureCanvas):
 
         context.set_antialias(1)
         context.set_line_width(lw)
-        context.rectangle(x0, y0, w, h)
+        context.rectangle(x0 + lw, y0 + lw, w - (2 * lw) , h - (2 - lw))
         #input are floats so divide rgb value by 255
+        context.set_source_rgba(120 / 255, 174 / 255, 237 / 255, 0.2)
+        context.fill()
+        context.rectangle(x0, y0, w, h)
         context.set_source_rgba(120 / 255, 174 / 255, 237 / 255, 1)
         context.stroke()
 

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -25,7 +25,7 @@ def define_highlight(self, span=None):
         lambda x, y: x,
         "horizontal",
         useblit=True,
-        props=dict(alpha=0.3, facecolor = "tab:blue", linewidth = 0),
+        props=dict(facecolor = (120 / 255, 174 / 255, 237 / 255, 0.2), edgecolor = (120 / 255, 174 / 255, 237 / 255, 1), linewidth = 1),
         handle_props=dict(linewidth=0),
         interactive=True,
         drag_from_anywhere=True)

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -660,7 +660,7 @@ class PlotWidget(FigureCanvas):
 
         context.set_antialias(1)
         context.set_line_width(lw)
-        context.rectangle(x0 + lw, y0 + lw, w - (2 * lw) , h - (2 - lw))
+        context.rectangle(x0, y0, w, h)
         #input are floats so divide rgb value by 255
         context.set_source_rgba(120 / 255, 174 / 255, 237 / 255, 0.2)
         context.fill()

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Gdk
 from enum import Enum
+from matplotlib.backend_bases import NavigationToolbar2
 
 from .data import Data
 
@@ -139,4 +140,19 @@ class InteractionMode(Enum):
     PAN = 2
     ZOOM = 3
     SELECT = 4
+
+class DummyToolbar(NavigationToolbar2):
+    """
+    Own implementation of NavigationToolbar2. Needed for rubberband support.
+    """
+    def __init__(self, canvas):
+        super().__init__(canvas)
+
+    def draw_rubberband(self, event, x0, y0, x1, y1):
+        self.canvas._rubberband_rect = [int(val) for val in (x0, self.canvas.figure.bbox.height - y0, x1 - x0, y0 - y1)]
+        self.canvas.queue_draw()
+
+    def remove_rubberband(self):
+        self.canvas._rubberband_rect = None
+        self.canvas.queue_draw()
 


### PR DESCRIPTION
This has a few changes to make this feature work:

- `DummyToolbar` Class based on `backend_bases` version of `NavigationToolbar`. This eliminates any unnecessary overhead from having unrendered gtk widgets, and gtk-releated stuff, that we don't use anyway. Since `backend_bases` does not implement the `draw_rubberband` function this is implemented as well (even more optimized than the upstream matplotlib implementation)
- A `_post_draw` classfunction in `PlotWidget`. This overrides matplotlibs implementation of a rubberband by hooking into existing code and just changing the way its actually rendered: using a full rectangle with a style-matching colour instead of a dashed rectangle like before.

Screenshot:
![grafik](https://user-images.githubusercontent.com/59118042/217634182-0c4d82bc-4fd1-4dba-b54e-391afb004db6.png)
