### PR TITLE
Linting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
         cache-key: flatpak-builder-${{ github.sha }}
 
   flake8-lint:
-    runs-on: ubuntu-latest
     name: flake8
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
       - name: Set up Python environment
@@ -32,3 +32,4 @@ jobs:
         uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,34 @@
-on:
-  push:
-    branches: [main]
-  pull_request:
+on: [push, pull_request]
 name: CI
 jobs:
   flatpak:
-    name: "build-packages"
+    name: "build-flatpak"
     runs-on: ubuntu-latest
     container:
       image: bilelmoussaoui/flatpak-github-actions:gnome-43
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
     - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: graphs.flatpak
         manifest-path: se.sjoerd.Graphs.json
         cache-key: flatpak-builder-${{ github.sha }}
+
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: flake8
+    steps:
+      - uses: actions/checkout@main
+      - name: Set up Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      # Install specific flake8 version (this step is not required. Default is "latest").
+      - run: pip install flake8==6.0.0
+      # Install flake8 extensions (this step is not required. Default is "None").
+      - run: pip install flake8-docstrings flake8-simplify flake8-unused-arguments flake8-quotes
+      - name: flake8 Lint
+        uses: reviewdog/action-flake8@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/actions.py
+++ b/src/actions.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Main actions."""
-from graphs import graphs, item_operations, plot_settings, plotting_tools, ui, utilities
+from graphs import graphs, item_operations, plotting_tools, ui, utilities
 from graphs.add_data_advanced import AddAdvancedWindow
 from graphs.add_equation import AddEquationWindow
+from graphs.plot_settings import PlotSettingsWindow
 from graphs.preferences import PreferencesWindow
 from graphs.transform_data import TransformWindow
 
@@ -21,7 +22,8 @@ def preferences_action(_action, _target, self):
 
 
 def plot_settings_action(_action, _target, self):
-    plot_settings.open_plot_settings(self)
+    win = PlotSettingsWindow(self)
+    win.present()
 
 
 def add_data_action(_action, _target, self):
@@ -42,7 +44,7 @@ def select_all_action(_action, _target, self):
     for _key, item in self.item_rows.items():
         item.check_button.set_active(True)
     plotting_tools.refresh_plot(self)
-    ui.enable_data_dependent_buttons(self, True)
+    ui.enable_data_dependent_buttons(self, utilities.get_selected_keys(self))
 
 
 def select_none_action(_action, _target, self):

--- a/src/actions.py
+++ b/src/actions.py
@@ -61,7 +61,7 @@ def redo_action(_action, _target, self):
 
 
 def restore_view_action(_action, _target, self):
-    plotting_tools.set_canvas_limits_axis(self, self.canvas)
+    plotting_tools.set_canvas_limits_axis(self)
     self.canvas.draw()
 
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -7,151 +7,151 @@ from graphs.preferences import PreferencesWindow
 from graphs.transform_data import TransformWindow
 
 
-def quit_action(action, target, self):
+def quit_action(_action, _target, self):
     self.quit()
 
 
-def about_action(action, target, self):
+def about_action(_action, _target, self):
     ui.show_about_window(self)
 
 
-def preferences_action(action, target, self):
+def preferences_action(_action, _target, self):
     win = PreferencesWindow(self)
     win.present()
 
 
-def plot_settings_action(action, target, self):
+def plot_settings_action(_action, _target, self):
     plot_settings.open_plot_settings(self)
 
 
-def add_data_action(action, target, self):
+def add_data_action(_action, _target, self):
     ui.open_file_dialog(self, False)
 
 
-def add_data_advanced_action(action, target, self):
+def add_data_advanced_action(_action, _target, self):
     win = AddAdvancedWindow(self)
     win.present()
 
 
-def add_equation_action(action, target, self):
+def add_equation_action(_action, _target, self):
     win = AddEquationWindow(self)
     win.present()
 
 
-def select_all_action(action, target, self):
-    for key, item in self.item_rows.items():
+def select_all_action(_action, _target, self):
+    for _key, item in self.item_rows.items():
         item.check_button.set_active(True)
     plotting_tools.refresh_plot(self)
     ui.enable_data_dependent_buttons(self, True)
 
 
-def select_none_action(action, target, self):
-    for key, item in self.item_rows.items():
+def select_none_action(_action, _target, self):
+    for _key, item in self.item_rows.items():
         item.check_button.set_active(False)
     plotting_tools.refresh_plot(self)
     ui.enable_data_dependent_buttons(self, False)
 
 
-def undo_action(action, target, self):
+def undo_action(_action, _target, self):
     item_operations.undo(self)
 
 
-def redo_action(action, target, self):
+def redo_action(_action, _target, self):
     item_operations.redo(self)
 
 
-def restore_view_action(action, target, self):
+def restore_view_action(_action, _target, self):
     plotting_tools.set_canvas_limits_axis(self, self.canvas)
     self.canvas.draw()
 
 
-def view_back_action(action, target, self):
+def view_back_action(_action, _target, self):
     self.dummy_toolbar._nav_stack.back()
     self.dummy_toolbar._update_view()
 
 
-def view_forward_action(action, target, self):
+def view_forward_action(_action, _target, self):
     self.dummy_toolbar._nav_stack.forward()
     self.dummy_toolbar._update_view()
 
 
-def export_data_action(action, target, self):
+def export_data_action(_action, _target, self):
     ui.save_file_dialog(self)
 
 
-def export_figure_action(action, target, self):
+def export_figure_action(_action, _target, self):
     ui.export_figure(self)
 
 
-def save_project_action(action, target, self):
+def save_project_action(_action, _target, self):
     ui.save_project_dialog(self)
 
 
-def open_project_action(action, target, self):
+def open_project_action(_action, _target, self):
     ui.open_file_dialog(self, True)
 
 
-def delete_selected_action(action, target, self):
+def delete_selected_action(_action, _target, self):
     for key in utilities.get_selected_keys(self):
         graphs.delete(self, key, True)
 
 
-def translate_x_action(action, target, self):
+def translate_x_action(_action, _target, self):
     item_operations.translate_x(self)
 
 
-def translate_y_action(action, target, self):
+def translate_y_action(_action, _target, self):
     item_operations.translate_y(self)
 
 
-def multiply_x_action(action, target, self):
+def multiply_x_action(_action, _target, self):
     item_operations.multiply_x(self)
 
 
-def multiply_y_action(action, target, self):
+def multiply_y_action(_action, _target, self):
     item_operations.multiply_y(self)
 
 
-def normalize_action(action, target, self):
+def normalize_action(_action, _target, self):
     item_operations.normalize_data(self)
 
 
-def smoothen_action(action, target, self):
+def smoothen_action(_action, _target, self):
     item_operations.smoothen_data(self)
 
 
-def center_action(action, target, self):
+def center_action(_action, _target, self):
     item_operations.center_data(self)
 
 
-def shift_vertically_action(action, target, self):
+def shift_vertically_action(_action, _target, self):
     item_operations.shift_vertically(self)
 
 
-def combine_action(action, target, self):
+def combine_action(_action, _target, self):
     item_operations.combine_data(self)
 
 
-def cut_selected_action(action, target, self):
+def cut_selected_action(_action, _target, self):
     item_operations.cut_data(self)
 
 
-def get_derivative_action(action, target, self):
+def get_derivative_action(_action, _target, self):
     item_operations.get_derivative(self)
 
 
-def get_integral_action(action, target, self):
+def get_integral_action(_action, _target, self):
     item_operations.get_integral(self)
 
 
-def get_fourier_action(action, target, self):
+def get_fourier_action(_action, _target, self):
     item_operations.get_fourier(self)
 
 
-def get_inverse_fourier_action(action, target, self):
+def get_inverse_fourier_action(_action, _target, self):
     item_operations.get_inverse_fourier(self)
 
 
-def transform_action(action, target, self):
+def transform_action(_action, _target, self):
     win = TransformWindow(self)
     win.present()

--- a/src/actions.py
+++ b/src/actions.py
@@ -1,34 +1,42 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from . import ui, utilities, plot_settings, graphs, item_operations, plotting_tools
-from .misc import InteractionMode
-from .preferences import PreferencesWindow
-from .add_data_advanced import AddAdvancedWindow
-from .add_equation import AddEquationWindow
-from .transform_data import TransformWindow
+"""Main actions."""
+from graphs import graphs, item_operations, plot_settings, plotting_tools, ui, utilities
+from graphs.add_data_advanced import AddAdvancedWindow
+from graphs.add_equation import AddEquationWindow
+from graphs.preferences import PreferencesWindow
+from graphs.transform_data import TransformWindow
+
 
 def quit_action(action, target, self):
     self.quit()
 
+
 def about_action(action, target, self):
     ui.show_about_window(self)
+
 
 def preferences_action(action, target, self):
     win = PreferencesWindow(self)
     win.present()
 
+
 def plot_settings_action(action, target, self):
     plot_settings.open_plot_settings(self)
 
+
 def add_data_action(action, target, self):
     ui.open_file_dialog(self, False)
+
 
 def add_data_advanced_action(action, target, self):
     win = AddAdvancedWindow(self)
     win.present()
 
+
 def add_equation_action(action, target, self):
     win = AddEquationWindow(self)
     win.present()
+
 
 def select_all_action(action, target, self):
     for key, item in self.item_rows.items():
@@ -36,87 +44,113 @@ def select_all_action(action, target, self):
     plotting_tools.refresh_plot(self)
     ui.enable_data_dependent_buttons(self, True)
 
+
 def select_none_action(action, target, self):
     for key, item in self.item_rows.items():
         item.check_button.set_active(False)
     plotting_tools.refresh_plot(self)
     ui.enable_data_dependent_buttons(self, False)
 
+
 def undo_action(action, target, self):
     item_operations.undo(self)
 
+
 def redo_action(action, target, self):
     item_operations.redo(self)
+
 
 def restore_view_action(action, target, self):
     plotting_tools.set_canvas_limits_axis(self, self.canvas)
     self.canvas.draw()
 
+
 def view_back_action(action, target, self):
     self.dummy_toolbar._nav_stack.back()
     self.dummy_toolbar._update_view()
+
 
 def view_forward_action(action, target, self):
     self.dummy_toolbar._nav_stack.forward()
     self.dummy_toolbar._update_view()
 
+
 def export_data_action(action, target, self):
     ui.save_file_dialog(self)
+
 
 def export_figure_action(action, target, self):
     ui.export_figure(self)
 
+
 def save_project_action(action, target, self):
     ui.save_project_dialog(self)
 
+
 def open_project_action(action, target, self):
     ui.open_file_dialog(self, True)
+
 
 def delete_selected_action(action, target, self):
     for key in utilities.get_selected_keys(self):
         graphs.delete(self, key, True)
 
+
 def translate_x_action(action, target, self):
     item_operations.translate_x(self)
+
 
 def translate_y_action(action, target, self):
     item_operations.translate_y(self)
 
+
 def multiply_x_action(action, target, self):
     item_operations.multiply_x(self)
+
 
 def multiply_y_action(action, target, self):
     item_operations.multiply_y(self)
 
+
 def normalize_action(action, target, self):
     item_operations.normalize_data(self)
+
 
 def smoothen_action(action, target, self):
     item_operations.smoothen_data(self)
 
+
 def center_action(action, target, self):
     item_operations.center_data(self)
+
 
 def shift_vertically_action(action, target, self):
     item_operations.shift_vertically(self)
 
+
 def combine_action(action, target, self):
     item_operations.combine_data(self)
+
 
 def cut_selected_action(action, target, self):
     item_operations.cut_data(self)
 
+
 def get_derivative_action(action, target, self):
     item_operations.get_derivative(self)
+
 
 def get_integral_action(action, target, self):
     item_operations.get_integral(self)
 
+
 def get_fourier_action(action, target, self):
     item_operations.get_fourier(self)
 
+
 def get_inverse_fourier_action(action, target, self):
     item_operations.get_inverse_fourier(self)
+
 
 def transform_action(action, target, self):
     win = TransformWindow(self)

--- a/src/add_data_advanced.py
+++ b/src/add_data_advanced.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Gtk, Adw
+from gi.repository import Adw, Gtk
 
-from . import graphs, utilities, ui
-from .misc import ImportSettings
+from graphs import ui, utilities
+from graphs.misc import ImportSettings
+
 
 def on_accept(widget, self, window):
     """
-    Runs when the dataset is loaded, uses the selected settings in the window 
+    Runs when the dataset is loaded, uses the selected settings in the window
     to set the import settings during loading
     """
     import_settings = ImportSettings
@@ -19,6 +20,7 @@ def on_accept(widget, self, window):
     import_settings.name = window.name.get_text()
     ui.open_file_dialog(self, False, import_settings)
     window.destroy()
+
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/add_data_advanced.ui')
 class AddAdvancedWindow(Adw.Window):

--- a/src/add_data_advanced.py
+++ b/src/add_data_advanced.py
@@ -20,9 +20,9 @@ def on_accept(widget, self, window):
     ui.open_file_dialog(self, False, import_settings)
     window.destroy()
 
-@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/add_data_advanced.ui")
+@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/add_data_advanced.ui')
 class AddAdvancedWindow(Adw.Window):
-    __gtype_name__ = "AddAdvancedWindow"
+    __gtype_name__ = 'AddAdvancedWindow'
     delimiter = Gtk.Template.Child()
     separator = Gtk.Template.Child()
     column_x = Gtk.Template.Child()
@@ -35,14 +35,14 @@ class AddAdvancedWindow(Adw.Window):
     def __init__(self, parent):
         super().__init__()
         config = parent.preferences.config
-        self.skip_rows.set_value(int(config["import_skip_rows"]))
-        self.column_y.set_value(int(config["import_column_y"]))
-        self.column_x.set_value(int(config["import_column_x"]))
-        self.delimiter.set_text(config["import_delimiter"])
-        utilities.set_chooser(self.separator, config["import_separator"])
-        self.guess_headers.set_active(config["guess_headers"])
+        self.skip_rows.set_value(int(config['import_skip_rows']))
+        self.column_y.set_value(int(config['import_column_y']))
+        self.column_x.set_value(int(config['import_column_x']))
+        self.delimiter.set_text(config['import_delimiter'])
+        utilities.set_chooser(self.separator, config['import_separator'])
+        self.guess_headers.set_active(config['guess_headers'])
         style_context = self.open_advanced_confirm_button.get_style_context()
-        style_context.add_class("suggested-action")
-        self.open_advanced_confirm_button.connect("clicked", on_accept, parent, self)
+        style_context.add_class('suggested-action')
+        self.open_advanced_confirm_button.connect('clicked', on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/add_data_advanced.py
+++ b/src/add_data_advanced.py
@@ -14,7 +14,8 @@ def on_accept(_widget, self, window):
     import_settings.column_x = int(window.column_x.get_value())
     import_settings.column_y = int(window.column_y.get_value())
     import_settings.skip_rows = int(window.skip_rows.get_value())
-    import_settings.separator = window.separator.get_selected_item().get_string()
+    import_settings.separator = window.separator.get_selected_item(
+    ).get_string()
     import_settings.delimiter = window.delimiter.get_text()
     import_settings.guess_headers = window.guess_headers.get_active()
     import_settings.name = window.name.get_text()
@@ -45,6 +46,7 @@ class AddAdvancedWindow(Adw.Window):
         self.guess_headers.set_active(config["guess_headers"])
         style_context = self.open_advanced_confirm_button.get_style_context()
         style_context.add_class("suggested-action")
-        self.open_advanced_confirm_button.connect("clicked", on_accept, parent, self)
+        self.open_advanced_confirm_button.connect(
+            "clicked", on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/add_data_advanced.py
+++ b/src/add_data_advanced.py
@@ -22,9 +22,9 @@ def on_accept(_widget, self, window):
     window.destroy()
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/add_data_advanced.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/add_data_advanced.ui")
 class AddAdvancedWindow(Adw.Window):
-    __gtype_name__ = 'AddAdvancedWindow'
+    __gtype_name__ = "AddAdvancedWindow"
     delimiter = Gtk.Template.Child()
     separator = Gtk.Template.Child()
     column_x = Gtk.Template.Child()
@@ -37,14 +37,14 @@ class AddAdvancedWindow(Adw.Window):
     def __init__(self, parent):
         super().__init__()
         config = parent.preferences.config
-        self.skip_rows.set_value(int(config['import_skip_rows']))
-        self.column_y.set_value(int(config['import_column_y']))
-        self.column_x.set_value(int(config['import_column_x']))
-        self.delimiter.set_text(config['import_delimiter'])
-        utilities.set_chooser(self.separator, config['import_separator'])
-        self.guess_headers.set_active(config['guess_headers'])
+        self.skip_rows.set_value(int(config["import_skip_rows"]))
+        self.column_y.set_value(int(config["import_column_y"]))
+        self.column_x.set_value(int(config["import_column_x"]))
+        self.delimiter.set_text(config["import_delimiter"])
+        utilities.set_chooser(self.separator, config["import_separator"])
+        self.guess_headers.set_active(config["guess_headers"])
         style_context = self.open_advanced_confirm_button.get_style_context()
-        style_context.add_class('suggested-action')
-        self.open_advanced_confirm_button.connect('clicked', on_accept, parent, self)
+        style_context.add_class("suggested-action")
+        self.open_advanced_confirm_button.connect("clicked", on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/add_data_advanced.py
+++ b/src/add_data_advanced.py
@@ -5,7 +5,7 @@ from graphs import ui, utilities
 from graphs.misc import ImportSettings
 
 
-def on_accept(widget, self, window):
+def on_accept(_widget, self, window):
     """
     Runs when the dataset is loaded, uses the selected settings in the window
     to set the import settings during loading

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -9,9 +9,7 @@ from numpy import *
 
 
 def on_accept(_widget, self, window):
-    """
-    Launched when the accept button is pressed on the equation window
-    """
+    """Launched when the accept button is pressed on the equation window"""
     x_start = window.X_start_entry.get_text()
     x_stop = window.X_stop_entry.get_text()
     step_size = window.step_size_entry.get_text()
@@ -55,9 +53,7 @@ def on_accept(_widget, self, window):
 
 
 def create_dataset(x_start, x_stop, equation, step_size, name):
-    """
-    Create all data set parameters that are required to create a new data object
-    """
+    """Create all data set parameters that are required to create a new data object"""
     dataset = {}
     if name == '':
         name = f'Y = {str(equation)}'

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Gtk, Adw
+from gi.repository import Adw, Gtk
+
+from graphs import graphs, plotting_tools, utilities
+from graphs.data import Data
+
 from numpy import *
-from . import plotting_tools, graphs, utilities
-from .data import Data
+
 
 def open_add_equation_window(self):
     """
@@ -27,8 +30,8 @@ def on_accept(widget, self, window):
         window.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type} - Unable to add data from equation'))
         return
 
-    #Choose how to handle duplicates filenames. Add them, ignore them, overide them,
-    #Or rename the file
+    # Choose how to handle duplicates filenames. Add them, ignore them, overide them,
+    # Or rename the file
     handle_duplicates = self.preferences.config['handle_duplicates']
     if not handle_duplicates == 'Add duplicates':
         for key, item in self.datadict.items():
@@ -46,7 +49,7 @@ def on_accept(widget, self, window):
                     plotting_tools.refresh_plot(self)
                     window.destroy()
                     return
-            
+
     new_file.xdata_clipboard = [new_file.xdata.copy()]
     new_file.ydata_clipboard = [new_file.ydata.copy()]
     new_file.clipboard_pos = -1
@@ -56,23 +59,23 @@ def on_accept(widget, self, window):
     window.destroy()
 
 
-    
 def create_dataset(self, x_start, x_stop, equation, step_size, name):
     """
     Create all data set parameters that are required to create a new data object
     """
-    dataset = dict()
+    dataset = {}
     if name == '':
         name = f'Y = {str(equation)}'
     dataset['name'] = name
-    datapoints = int(abs(eval(x_start) - eval(x_stop))/eval(step_size))
-    xdata =  linspace(eval(x_start),eval(x_stop),datapoints)
+    datapoints = int(abs(eval(x_start) - eval(x_stop)) / eval(step_size))
+    xdata = linspace(eval(x_start), eval(x_stop), datapoints)
     equation = equation.replace('X', 'xdata')
     equation = str(equation.replace('^', '**'))
     equation += ' + xdata*0'
     dataset['ydata'] = eval(equation)
     dataset['xdata'] = ndarray.tolist(xdata)
     return dataset
+
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/add_equation_window.ui')
 class AddEquationWindow(Adw.Window):

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -14,25 +14,29 @@ def on_accept(_widget, self, window):
     x_stop = window.X_stop_entry.get_text()
     step_size = window.step_size_entry.get_text()
     equation = str(window.equation_entry.get_text())
-    dataset = create_dataset(x_start, x_stop, equation, step_size, str(window.name_entry.get_text()))
+    dataset = create_dataset(x_start, x_stop, equation, step_size,
+                             str(window.name_entry.get_text()))
     try:
         new_file = Data(self, dataset["xdata"], dataset["ydata"])
         new_file.filename = dataset["name"]
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        window.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type} - Unable to add data from equation"))
+        toast = f"{exception_type} - Unable to add data from equation"
+        window.toast_overlay.add_toast(Adw.Toast(title=toast))
         return
 
-    # Choose how to handle duplicates filenames. Add them, ignore them, overide them,
-    # Or rename the file
+    # Choose how to handle duplicates filenames. Add them,
+    # ignore them, overide them, Or rename the file
     handle_duplicates = self.preferences.config["handle_duplicates"]
     if not handle_duplicates == "Add duplicates":
         for key, item in self.datadict.items():
             if new_file.filename in item.filename:
                 if handle_duplicates == "Auto-rename duplicates":
-                    new_file.filename = utilities.get_duplicate_filename(self, new_file.filename)
+                    new_file.filename = utilities.get_duplicate_filename(
+                        self, new_file.filename)
                 elif handle_duplicates == "Ignore duplicates":
-                    window.toast_overlay.add_toast(Adw.Toast(title="Item with this name already exists"))
+                    toast = "Item with this name already exists"
+                    window.toast_overlay.add_toast(Adw.Toast(title=toast))
                     return
                 elif handle_duplicates == "Override existing items":
                     new_file.xdata_clipboard = [new_file.xdata.copy()]
@@ -48,12 +52,16 @@ def on_accept(_widget, self, window):
     new_file.clipboard_pos = -1
     color = plotting_tools.get_next_color(self)
     self.datadict[new_file.key] = new_file
-    graphs.add_sample_to_menu(self, new_file.filename, color, new_file.key, True)
+    graphs.add_sample_to_menu(self, new_file.filename,
+                              color, new_file.key, True)
     window.destroy()
 
 
 def create_dataset(x_start, x_stop, equation, step_size, name):
-    """Create all data set parameters that are required to create a new data object"""
+    """
+    Create all data set parameters that are required
+    to create a new data object
+    """
     dataset = {}
     if name == "":
         name = f"Y = {str(equation)}"
@@ -81,13 +89,18 @@ class AddEquationWindow(Adw.Window):
 
     def __init__(self, parent):
         super().__init__()
-        self.step_size_entry.set_text(parent.preferences.config["addequation_step_size"])
-        self.X_start_entry.set_text(parent.preferences.config["addequation_X_start"])
-        self.X_stop_entry.set_text(parent.preferences.config["addequation_X_stop"])
-        self.equation_entry.set_text(parent.preferences.config["addequation_equation"])
+        self.step_size_entry.set_text(
+            parent.preferences.config["addequation_step_size"])
+        self.X_start_entry.set_text(
+            parent.preferences.config["addequation_X_start"])
+        self.X_stop_entry.set_text(
+            parent.preferences.config["addequation_X_stop"])
+        self.equation_entry.set_text(
+            parent.preferences.config["addequation_equation"])
 
         style_context = self.add_equation_confirm_button.get_style_context()
         style_context.add_class("suggested-action")
-        self.add_equation_confirm_button.connect("clicked", on_accept, parent, self)
+        self.add_equation_confirm_button.connect("clicked", on_accept,
+                                                 parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -4,6 +4,7 @@ from gi.repository import Adw, Gtk
 from graphs import graphs, plotting_tools, utilities
 from graphs.data import Data
 
+import numpy
 from numpy import *
 
 
@@ -68,12 +69,12 @@ def create_dataset(self, x_start, x_stop, equation, step_size, name):
         name = f'Y = {str(equation)}'
     dataset['name'] = name
     datapoints = int(abs(eval(x_start) - eval(x_stop)) / eval(step_size))
-    xdata = linspace(eval(x_start), eval(x_stop), datapoints)
+    xdata = numpy.linspace(eval(x_start), eval(x_stop), datapoints)
     equation = equation.replace('X', 'xdata')
     equation = str(equation.replace('^', '**'))
     equation += ' + xdata*0'
     dataset['ydata'] = eval(equation)
-    dataset['xdata'] = ndarray.tolist(xdata)
+    dataset['xdata'] = numpy.ndarray.tolist(xdata)
     return dataset
 
 

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -25,8 +25,8 @@ def on_accept(widget, self, window):
     try:
         new_file = Data(self, dataset['xdata'], dataset['ydata'])
         new_file.filename = dataset['name']
-    except Exception as e:
-        exception_type = e.__class__.__name__
+    except Exception as exception:
+        exception_type = exception.__class__.__name__
         window.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type} - Unable to add data from equation'))
         return
 

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -16,25 +16,25 @@ def on_accept(_widget, self, window):
     equation = str(window.equation_entry.get_text())
     dataset = create_dataset(x_start, x_stop, equation, step_size, str(window.name_entry.get_text()))
     try:
-        new_file = Data(self, dataset['xdata'], dataset['ydata'])
-        new_file.filename = dataset['name']
+        new_file = Data(self, dataset["xdata"], dataset["ydata"])
+        new_file.filename = dataset["name"]
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        window.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type} - Unable to add data from equation'))
+        window.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type} - Unable to add data from equation"))
         return
 
     # Choose how to handle duplicates filenames. Add them, ignore them, overide them,
     # Or rename the file
-    handle_duplicates = self.preferences.config['handle_duplicates']
-    if not handle_duplicates == 'Add duplicates':
+    handle_duplicates = self.preferences.config["handle_duplicates"]
+    if not handle_duplicates == "Add duplicates":
         for key, item in self.datadict.items():
             if new_file.filename in item.filename:
-                if handle_duplicates == 'Auto-rename duplicates':
+                if handle_duplicates == "Auto-rename duplicates":
                     new_file.filename = utilities.get_duplicate_filename(self, new_file.filename)
-                elif handle_duplicates == 'Ignore duplicates':
-                    window.toast_overlay.add_toast(Adw.Toast(title='Item with this name already exists'))
+                elif handle_duplicates == "Ignore duplicates":
+                    window.toast_overlay.add_toast(Adw.Toast(title="Item with this name already exists"))
                     return
-                elif handle_duplicates == 'Override existing items':
+                elif handle_duplicates == "Override existing items":
                     new_file.xdata_clipboard = [new_file.xdata.copy()]
                     new_file.ydata_clipboard = [new_file.ydata.copy()]
                     new_file.clipboard_pos = -1
@@ -55,22 +55,22 @@ def on_accept(_widget, self, window):
 def create_dataset(x_start, x_stop, equation, step_size, name):
     """Create all data set parameters that are required to create a new data object"""
     dataset = {}
-    if name == '':
-        name = f'Y = {str(equation)}'
-    dataset['name'] = name
+    if name == "":
+        name = f"Y = {str(equation)}"
+    dataset["name"] = name
     datapoints = int(abs(eval(x_start) - eval(x_stop)) / eval(step_size))
     xdata = numpy.linspace(eval(x_start), eval(x_stop), datapoints)
-    equation = equation.replace('X', 'xdata')
-    equation = str(equation.replace('^', '**'))
-    equation += ' + xdata*0'
-    dataset['ydata'] = eval(equation)
-    dataset['xdata'] = numpy.ndarray.tolist(xdata)
+    equation = equation.replace("X", "xdata")
+    equation = str(equation.replace("^", "**"))
+    equation += " + xdata*0"
+    dataset["ydata"] = eval(equation)
+    dataset["xdata"] = numpy.ndarray.tolist(xdata)
     return dataset
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/add_equation_window.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/add_equation_window.ui")
 class AddEquationWindow(Adw.Window):
-    __gtype_name__ = 'AddEquationWindow'
+    __gtype_name__ = "AddEquationWindow"
     add_equation_confirm_button = Gtk.Template.Child()
     step_size_entry = Gtk.Template.Child()
     X_stop_entry = Gtk.Template.Child()
@@ -81,13 +81,13 @@ class AddEquationWindow(Adw.Window):
 
     def __init__(self, parent):
         super().__init__()
-        self.step_size_entry.set_text(parent.preferences.config['addequation_step_size'])
-        self.X_start_entry.set_text(parent.preferences.config['addequation_X_start'])
-        self.X_stop_entry.set_text(parent.preferences.config['addequation_X_stop'])
-        self.equation_entry.set_text(parent.preferences.config['addequation_equation'])
+        self.step_size_entry.set_text(parent.preferences.config["addequation_step_size"])
+        self.X_start_entry.set_text(parent.preferences.config["addequation_X_start"])
+        self.X_stop_entry.set_text(parent.preferences.config["addequation_X_stop"])
+        self.equation_entry.set_text(parent.preferences.config["addequation_equation"])
 
         style_context = self.add_equation_confirm_button.get_style_context()
-        style_context.add_class('suggested-action')
-        self.add_equation_confirm_button.connect('clicked', on_accept, parent, self)
+        style_context.add_class("suggested-action")
+        self.add_equation_confirm_button.connect("clicked", on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -20,25 +20,25 @@ def on_accept(widget, self, window):
     equation = str(window.equation_entry.get_text())
     dataset = create_dataset(self, x_start, x_stop, equation, step_size, str(window.name_entry.get_text()))
     try:
-        new_file = Data(self, dataset["xdata"], dataset["ydata"])
-        new_file.filename = dataset["name"]
+        new_file = Data(self, dataset['xdata'], dataset['ydata'])
+        new_file.filename = dataset['name']
     except Exception as e:
         exception_type = e.__class__.__name__
-        window.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type} - Unable to add data from equation"))
+        window.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type} - Unable to add data from equation'))
         return
 
     #Choose how to handle duplicates filenames. Add them, ignore them, overide them,
     #Or rename the file
-    handle_duplicates = self.preferences.config["handle_duplicates"]
-    if not handle_duplicates == "Add duplicates":
+    handle_duplicates = self.preferences.config['handle_duplicates']
+    if not handle_duplicates == 'Add duplicates':
         for key, item in self.datadict.items():
             if new_file.filename in item.filename:
-                if handle_duplicates == "Auto-rename duplicates":
+                if handle_duplicates == 'Auto-rename duplicates':
                     new_file.filename = utilities.get_duplicate_filename(self, new_file.filename)
-                elif handle_duplicates == "Ignore duplicates":
-                    window.toast_overlay.add_toast(Adw.Toast(title="Item with this name already exists"))
+                elif handle_duplicates == 'Ignore duplicates':
+                    window.toast_overlay.add_toast(Adw.Toast(title='Item with this name already exists'))
                     return
-                elif handle_duplicates == "Override existing items":
+                elif handle_duplicates == 'Override existing items':
                     new_file.xdata_clipboard = [new_file.xdata.copy()]
                     new_file.ydata_clipboard = [new_file.ydata.copy()]
                     new_file.clipboard_pos = -1
@@ -62,21 +62,21 @@ def create_dataset(self, x_start, x_stop, equation, step_size, name):
     Create all data set parameters that are required to create a new data object
     """
     dataset = dict()
-    if name == "":
-        name = f"Y = {str(equation)}"
-    dataset["name"] = name
+    if name == '':
+        name = f'Y = {str(equation)}'
+    dataset['name'] = name
     datapoints = int(abs(eval(x_start) - eval(x_stop))/eval(step_size))
     xdata =  linspace(eval(x_start),eval(x_stop),datapoints)
-    equation = equation.replace("X", "xdata")
-    equation = str(equation.replace("^", "**"))
-    equation += " + xdata*0"
-    dataset["ydata"] = eval(equation)
-    dataset["xdata"] = ndarray.tolist(xdata)
+    equation = equation.replace('X', 'xdata')
+    equation = str(equation.replace('^', '**'))
+    equation += ' + xdata*0'
+    dataset['ydata'] = eval(equation)
+    dataset['xdata'] = ndarray.tolist(xdata)
     return dataset
 
-@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/add_equation_window.ui")
+@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/add_equation_window.ui')
 class AddEquationWindow(Adw.Window):
-    __gtype_name__ = "AddEquationWindow"
+    __gtype_name__ = 'AddEquationWindow'
     add_equation_confirm_button = Gtk.Template.Child()
     step_size_entry = Gtk.Template.Child()
     X_stop_entry = Gtk.Template.Child()
@@ -87,13 +87,13 @@ class AddEquationWindow(Adw.Window):
 
     def __init__(self, parent):
         super().__init__()
-        self.step_size_entry.set_text(parent.preferences.config["addequation_step_size"])
-        self.X_start_entry.set_text(parent.preferences.config["addequation_X_start"])
-        self.X_stop_entry.set_text(parent.preferences.config["addequation_X_stop"])
-        self.equation_entry.set_text(parent.preferences.config["addequation_equation"])        
+        self.step_size_entry.set_text(parent.preferences.config['addequation_step_size'])
+        self.X_start_entry.set_text(parent.preferences.config['addequation_X_start'])
+        self.X_stop_entry.set_text(parent.preferences.config['addequation_X_stop'])
+        self.equation_entry.set_text(parent.preferences.config['addequation_equation'])
 
         style_context = self.add_equation_confirm_button.get_style_context()
-        style_context.add_class("suggested-action")
-        self.add_equation_confirm_button.connect("clicked", on_accept, parent, self)
+        style_context.add_class('suggested-action')
+        self.add_equation_confirm_button.connect('clicked', on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -8,13 +8,7 @@ import numpy
 from numpy import *
 
 
-def open_add_equation_window(self):
-    """
-    Open the window for adding a new dataset from an equation
-    """
-
-
-def on_accept(widget, self, window):
+def on_accept(_widget, self, window):
     """
     Launched when the accept button is pressed on the equation window
     """
@@ -22,7 +16,7 @@ def on_accept(widget, self, window):
     x_stop = window.X_stop_entry.get_text()
     step_size = window.step_size_entry.get_text()
     equation = str(window.equation_entry.get_text())
-    dataset = create_dataset(self, x_start, x_stop, equation, step_size, str(window.name_entry.get_text()))
+    dataset = create_dataset(x_start, x_stop, equation, step_size, str(window.name_entry.get_text()))
     try:
         new_file = Data(self, dataset['xdata'], dataset['ydata'])
         new_file.filename = dataset['name']
@@ -60,7 +54,7 @@ def on_accept(widget, self, window):
     window.destroy()
 
 
-def create_dataset(self, x_start, x_stop, equation, step_size, name):
+def create_dataset(x_start, x_stop, equation, step_size, name):
     """
     Create all data set parameters that are required to create a new data object
     """

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -10,8 +10,8 @@ from numpy import *
 
 def on_accept(_widget, self, window):
     """Launched when the accept button is pressed on the equation window"""
-    x_start = window.X_start_entry.get_text()
-    x_stop = window.X_stop_entry.get_text()
+    x_start = window.x_start_entry.get_text()
+    x_stop = window.x_stop_entry.get_text()
     step_size = window.step_size_entry.get_text()
     equation = str(window.equation_entry.get_text())
     dataset = create_dataset(x_start, x_stop, equation, step_size,
@@ -81,8 +81,8 @@ class AddEquationWindow(Adw.Window):
     __gtype_name__ = "AddEquationWindow"
     add_equation_confirm_button = Gtk.Template.Child()
     step_size_entry = Gtk.Template.Child()
-    X_stop_entry = Gtk.Template.Child()
-    X_start_entry = Gtk.Template.Child()
+    x_stop_entry = Gtk.Template.Child()
+    x_start_entry = Gtk.Template.Child()
     equation_entry = Gtk.Template.Child()
     name_entry = Gtk.Template.Child()
     toast_overlay = Gtk.Template.Child()
@@ -91,9 +91,9 @@ class AddEquationWindow(Adw.Window):
         super().__init__()
         self.step_size_entry.set_text(
             parent.preferences.config["addequation_step_size"])
-        self.X_start_entry.set_text(
+        self.x_start_entry.set_text(
             parent.preferences.config["addequation_X_start"])
-        self.X_stop_entry.set_text(
+        self.x_stop_entry.set_text(
             parent.preferences.config["addequation_X_stop"])
         self.equation_entry.set_text(
             parent.preferences.config["addequation_equation"])

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -16,7 +16,7 @@ class Canvas(FigureCanvas):
     """
     Create the graph widget
     """
-    def __init__(self, parent, xlabel='', ylabel='', yscale='log', title='', scale='linear', style='adwaita'):
+    def __init__(self, parent):
         self.figure = Figure()
         self.figure.set_tight_layout(True)
         self.one_click_trigger = False
@@ -159,7 +159,7 @@ class Canvas(FigureCanvas):
         if self.right_label.contains(event)[0] and double_click:
             rename_label.open_rename_label_window(self.parent, self.right_label)
 
-    def _post_draw(self, widget, context):
+    def _post_draw(self, _widget, context):
         """
         Override with custom implementation of rubberband to allow for custom rubberband style
         @param context: https://pycairo.readthedocs.io/en/latest/reference/context.html

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -167,20 +167,20 @@ class Canvas(FigureCanvas):
         if self._rubberband_rect is None:
             return
 
-        lw = 1
+        line_width = 1
         if not self._context_is_scaled:
-            x0, y0, w, h = (dim / self.device_pixel_ratio
+            x_0, y_0, width, height = (dim / self.device_pixel_ratio
                             for dim in self._rubberband_rect)
         else:
-            x0, y0, w, h = self._rubberband_rect
-            lw *= self.device_pixel_ratio
+            x_0, y_0, width, height = self._rubberband_rect
+            line_width *= self.device_pixel_ratio
 
         context.set_antialias(1)
-        context.set_line_width(lw)
-        context.rectangle(x0, y0, w, h)
-        ca = self.rubberband_color
-        context.set_source_rgba(ca.red, ca.green, ca.blue, 0.3)
+        context.set_line_width(line_width)
+        context.rectangle(x_0, y_0, width, height)
+        color = self.rubberband_color
+        context.set_source_rgba(color.red, color.green, color.blue, 0.3)
         context.fill()
-        context.rectangle(x0, y0, w, h)
-        context.set_source_rgba(ca.red, ca.green, ca.blue, 1)
+        context.rectangle(x_0, y_0, width, height)
+        context.set_source_rgba(color.red, color.green, color.blue, 1)
         context.stroke()

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -13,9 +13,7 @@ from matplotlib.figure import Figure
 
 
 class Canvas(FigureCanvas):
-    """
-    Create the graph widget
-    """
+    """Create the graph widget"""
     def __init__(self, parent):
         self.figure = Figure()
         self.figure.set_tight_layout(True)
@@ -43,9 +41,7 @@ class Canvas(FigureCanvas):
         plt.rcParams['savefig.transparent'] = parent.preferences.config['savefig_transparent']
 
     def set_ax_properties(self, parent):
-        """
-        Set the properties that are related to the axes.
-        """
+        """Set the properties that are related to the axes."""
         self.title = self.ax.set_title(parent.plot_settings.title)
         self.bottom_label = self.ax.set_xlabel(parent.plot_settings.xlabel, fontweight=parent.plot_settings.font_weight)
         self.right_label = self.right_axis.set_ylabel(parent.plot_settings.right_label, fontweight=parent.plot_settings.font_weight)
@@ -59,9 +55,7 @@ class Canvas(FigureCanvas):
         self.set_ticks(parent)
 
     def set_ticks(self, parent):
-        """
-        Set the ticks that are to be used in the graph.
-        """
+        """Set the ticks that are to be used in the graph."""
         for axis in [self.top_right_axis, self.top_left_axis, self.ax, self.right_axis]:
             axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.major_tick_length, width=parent.plot_settings.major_tick_width, which='major')
             axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.minor_tick_length, width=parent.plot_settings.minor_tick_width, which='minor')
@@ -87,9 +81,7 @@ class Canvas(FigureCanvas):
                 axis.tick_params(which='both', left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
 
     def set_style(self, parent):
-        """
-        Set the plot style.
-        """
+        """Set the plot style."""
         plt.rcParams.update(plt.rcParamsDefault)
         if Adw.StyleManager.get_default().get_dark():
             self.figure.patch.set_facecolor('#242424')
@@ -114,9 +106,7 @@ class Canvas(FigureCanvas):
         plt.rcParams.update(params)
 
     def set_color_cycle(self, parent):
-        """
-        Set the color cycle that will be used for the graphs.
-        """
+        """Set the color cycle that will be used for the graphs."""
         cmap = parent.preferences.config['plot_color_cycle']
         reverse_dark = parent.preferences.config['plot_invert_color_cycle_dark']
         if Adw.StyleManager.get_default().get_dark() and reverse_dark:

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -20,7 +20,7 @@ class Canvas(FigureCanvas):
         self.one_click_trigger = False
         self.time_first_click = 0
         self.parent = parent
-        self.mpl_connect('button_release_event', self)
+        self.mpl_connect("button_release_event", self)
         self.set_style(parent)
         self.ax = self.figure.add_subplot(111)
         self.right_axis = self.ax.twinx()
@@ -29,7 +29,7 @@ class Canvas(FigureCanvas):
         self.set_ax_properties(parent)
         self.set_save_properties(parent)
         self.set_color_cycle(parent)
-        self.rubberband_color = utilities.lookup_color(parent, 'accent_color')
+        self.rubberband_color = utilities.lookup_color(parent, "accent_color")
         super().__init__(self.figure)
 
     def set_save_properties(self, parent):
@@ -37,8 +37,8 @@ class Canvas(FigureCanvas):
         Set the properties that are related to saving the figure. Currently
         limited to savefig, but will include the background colour soon.
         """
-        plt.rcParams['savefig.format'] = parent.preferences.config['savefig_filetype']
-        plt.rcParams['savefig.transparent'] = parent.preferences.config['savefig_transparent']
+        plt.rcParams["savefig.format"] = parent.preferences.config["savefig_filetype"]
+        plt.rcParams["savefig.transparent"] = parent.preferences.config["savefig_transparent"]
 
     def set_ax_properties(self, parent):
         """Set the properties that are related to the axes."""
@@ -57,62 +57,62 @@ class Canvas(FigureCanvas):
     def set_ticks(self, parent):
         """Set the ticks that are to be used in the graph."""
         for axis in [self.top_right_axis, self.top_left_axis, self.ax, self.right_axis]:
-            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.major_tick_length, width=parent.plot_settings.major_tick_width, which='major')
-            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.minor_tick_length, width=parent.plot_settings.minor_tick_width, which='minor')
-            axis.tick_params(axis='x', which='minor')
-            axis.tick_params(axis='y', which='minor')
+            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.major_tick_length, width=parent.plot_settings.major_tick_width, which="major")
+            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.minor_tick_length, width=parent.plot_settings.minor_tick_width, which="minor")
+            axis.tick_params(axis="x", which="minor")
+            axis.tick_params(axis="y", which="minor")
             axis.minorticks_on()
             top = False
             bottom = False
             left = False
             right = False
             for key in parent.datadict.keys():
-                if parent.datadict[key].plot_X_position == 'top':
+                if parent.datadict[key].plot_x_position == "top":
                     top = True
-                if parent.datadict[key].plot_X_position == 'bottom':
+                if parent.datadict[key].plot_x_position == "bottom":
                     bottom = True
-                if parent.datadict[key].plot_Y_position == 'left':
+                if parent.datadict[key].plot_y_position == "left":
                     left = True
-                if parent.datadict[key].plot_Y_position == 'right':
+                if parent.datadict[key].plot_y_position == "right":
                     right = True
             if not (top and bottom):
-                axis.tick_params(which='both', bottom=parent.plot_settings.tick_bottom, top=parent.plot_settings.tick_top)
+                axis.tick_params(which="both", bottom=parent.plot_settings.tick_bottom, top=parent.plot_settings.tick_top)
             if not (left and right):
-                axis.tick_params(which='both', left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
+                axis.tick_params(which="both", left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
 
     def set_style(self, parent):
         """Set the plot style."""
         plt.rcParams.update(plt.rcParamsDefault)
         if Adw.StyleManager.get_default().get_dark():
-            self.figure.patch.set_facecolor('#242424')
-            text_color = 'white'
+            self.figure.patch.set_facecolor("#242424")
+            text_color = "white"
         else:
-            self.figure.patch.set_facecolor('#fafafa')
-            text_color = 'black'
+            self.figure.patch.set_facecolor("#fafafa")
+            text_color = "black"
         params = {
-            'font.weight': parent.plot_settings.font_weight,
-            'font.sans-serif': parent.plot_settings.font_family,
-            'font.size': parent.plot_settings.font_size,
-            'axes.labelsize': parent.plot_settings.font_size,
-            'xtick.labelsize': parent.plot_settings.font_size,
-            'ytick.labelsize': parent.plot_settings.font_size,
-            'axes.titlesize': parent.plot_settings.font_size,
-            'legend.fontsize': parent.plot_settings.font_size,
-            'font.style': parent.plot_settings.font_style,
-            'mathtext.default': 'regular',
-            'axes.labelcolor': text_color,
+            "font.weight": parent.plot_settings.font_weight,
+            "font.sans-serif": parent.plot_settings.font_family,
+            "font.size": parent.plot_settings.font_size,
+            "axes.labelsize": parent.plot_settings.font_size,
+            "xtick.labelsize": parent.plot_settings.font_size,
+            "ytick.labelsize": parent.plot_settings.font_size,
+            "axes.titlesize": parent.plot_settings.font_size,
+            "legend.fontsize": parent.plot_settings.font_size,
+            "font.style": parent.plot_settings.font_style,
+            "mathtext.default": "regular",
+            "axes.labelcolor": text_color,
         }
         plt.style.use(parent.plot_settings.plot_style)
         plt.rcParams.update(params)
 
     def set_color_cycle(self, parent):
         """Set the color cycle that will be used for the graphs."""
-        cmap = parent.preferences.config['plot_color_cycle']
-        reverse_dark = parent.preferences.config['plot_invert_color_cycle_dark']
+        cmap = parent.preferences.config["plot_color_cycle"]
+        reverse_dark = parent.preferences.config["plot_invert_color_cycle_dark"]
         if Adw.StyleManager.get_default().get_dark() and reverse_dark:
-            cmap += '_r'
+            cmap += "_r"
         color_cycle = cycler(color=plt.get_cmap(cmap).colors)
-        self.color_cycle = color_cycle.by_key()['color']
+        self.color_cycle = color_cycle.by_key()["color"]
 
     def __call__(self, event):
         """
@@ -121,7 +121,7 @@ class Canvas(FigureCanvas):
         click, and if these were on a specific item (e.g. the title) it triggers
         a dialog to edit this item.
 
-        Unfortunately the GTK Doubleclick signal doesn't work with matplotlib
+        Unfortunately the GTK Doubleclick signal doesn"t work with matplotlib
         hence this custom function.
         """
         double_click = False

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -13,7 +13,7 @@ class Canvas(FigureCanvas):
     """
     Create the graph widget
     """
-    def __init__(self, parent, xlabel="", ylabel="", yscale = "log", title="", scale="linear", style = "adwaita"):
+    def __init__(self, parent, xlabel='', ylabel='', yscale = 'log', title='', scale='linear', style = 'adwaita'):
         self.figure = Figure()
         self.figure.set_tight_layout(True)
         self.one_click_trigger = False
@@ -36,8 +36,8 @@ class Canvas(FigureCanvas):
         Set the properties that are related to saving the figure. Currently
         limited to savefig, but will include the background colour soon.
         """
-        plt.rcParams["savefig.format"] = parent.preferences.config["savefig_filetype"]
-        plt.rcParams["savefig.transparent"] = parent.preferences.config["savefig_transparent"]
+        plt.rcParams['savefig.format'] = parent.preferences.config['savefig_filetype']
+        plt.rcParams['savefig.transparent'] = parent.preferences.config['savefig_transparent']
 
     def set_ax_properties(self, parent):
         """
@@ -60,8 +60,8 @@ class Canvas(FigureCanvas):
         Set the ticks that are to be used in the graph.
         """
         for axis in [self.top_right_axis, self.top_left_axis, self.ax, self.right_axis]:
-            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.major_tick_length, width=parent.plot_settings.major_tick_width, which="major")
-            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.minor_tick_length, width=parent.plot_settings.minor_tick_width, which="minor")
+            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.major_tick_length, width=parent.plot_settings.major_tick_width, which='major')
+            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.minor_tick_length, width=parent.plot_settings.minor_tick_width, which='minor')
             axis.tick_params(axis='x',which='minor')
             axis.tick_params(axis='y',which='minor')
             axis.minorticks_on()
@@ -70,18 +70,18 @@ class Canvas(FigureCanvas):
             left = False
             right = False
             for key in parent.datadict.keys():
-                if parent.datadict[key].plot_X_position == "top":
+                if parent.datadict[key].plot_X_position == 'top':
                     top = True
-                if parent.datadict[key].plot_X_position == "bottom":
+                if parent.datadict[key].plot_X_position == 'bottom':
                     bottom = True
-                if parent.datadict[key].plot_Y_position == "left":
+                if parent.datadict[key].plot_Y_position == 'left':
                     left = True
-                if parent.datadict[key].plot_Y_position == "right":
+                if parent.datadict[key].plot_Y_position == 'right':
                     right = True
             if not (top and bottom):
-                axis.tick_params(which = "both", bottom=parent.plot_settings.tick_bottom, top=parent.plot_settings.tick_top)
+                axis.tick_params(which = 'both', bottom=parent.plot_settings.tick_bottom, top=parent.plot_settings.tick_top)
             if not (left and right):
-                axis.tick_params(which = "both", left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
+                axis.tick_params(which = 'both', left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
 
     def set_style(self, parent):
         """
@@ -89,23 +89,23 @@ class Canvas(FigureCanvas):
         """
         plt.rcParams.update(plt.rcParamsDefault)
         if Adw.StyleManager.get_default().get_dark():
-            self.figure.patch.set_facecolor("#242424")
-            text_color = "white"
+            self.figure.patch.set_facecolor('#242424')
+            text_color = 'white'
         else:
-            self.figure.patch.set_facecolor("#fafafa")
-            text_color = "black"
+            self.figure.patch.set_facecolor('#fafafa')
+            text_color = 'black'
         params = {
-        "font.weight": parent.plot_settings.font_weight,
-        "font.sans-serif": parent.plot_settings.font_family,
-        "font.size": parent.plot_settings.font_size,
-        "axes.labelsize": parent.plot_settings.font_size,
-        "xtick.labelsize": parent.plot_settings.font_size,
-        "ytick.labelsize": parent.plot_settings.font_size,
-        "axes.titlesize": parent.plot_settings.font_size,
-        "legend.fontsize": parent.plot_settings.font_size,
-        "font.style": parent.plot_settings.font_style,
-        "mathtext.default": "regular",
-        "axes.labelcolor" : text_color,
+        'font.weight': parent.plot_settings.font_weight,
+        'font.sans-serif': parent.plot_settings.font_family,
+        'font.size': parent.plot_settings.font_size,
+        'axes.labelsize': parent.plot_settings.font_size,
+        'xtick.labelsize': parent.plot_settings.font_size,
+        'ytick.labelsize': parent.plot_settings.font_size,
+        'axes.titlesize': parent.plot_settings.font_size,
+        'legend.fontsize': parent.plot_settings.font_size,
+        'font.style': parent.plot_settings.font_style,
+        'mathtext.default': 'regular',
+        'axes.labelcolor' : text_color,
         }
         plt.style.use(parent.plot_settings.plot_style)
         plt.rcParams.update(params)
@@ -114,10 +114,10 @@ class Canvas(FigureCanvas):
         """
         Set the color cycle that will be used for the graphs.
         """
-        cmap = parent.preferences.config["plot_color_cycle"]
-        reverse_dark = parent.preferences.config["plot_invert_color_cycle_dark"]
+        cmap = parent.preferences.config['plot_color_cycle']
+        reverse_dark = parent.preferences.config['plot_invert_color_cycle_dark']
         if Adw.StyleManager.get_default().get_dark() and reverse_dark:
-            cmap += "_r"
+            cmap += '_r'
         color_cycle = cycler(color=plt.get_cmap(cmap).colors)
         self.color_cycle = color_cycle.by_key()['color']
 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -170,7 +170,7 @@ class Canvas(FigureCanvas):
         line_width = 1
         if not self._context_is_scaled:
             x_0, y_0, width, height = (dim / self.device_pixel_ratio
-                            for dim in self._rubberband_rect)
+                                       for dim in self._rubberband_rect)
         else:
             x_0, y_0, width, height = self._rubberband_rect
             line_width *= self.device_pixel_ratio

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -37,16 +37,26 @@ class Canvas(FigureCanvas):
         Set the properties that are related to saving the figure. Currently
         limited to savefig, but will include the background colour soon.
         """
-        plt.rcParams["savefig.format"] = parent.preferences.config["savefig_filetype"]
-        plt.rcParams["savefig.transparent"] = parent.preferences.config["savefig_transparent"]
+        plt.rcParams["savefig.format"] = parent.preferences.config[
+            "savefig_filetype"]
+        plt.rcParams["savefig.transparent"] = parent.preferences.config[
+            "savefig_transparent"]
 
     def set_ax_properties(self, parent):
         """Set the properties that are related to the axes."""
         self.title = self.ax.set_title(parent.plot_settings.title)
-        self.bottom_label = self.ax.set_xlabel(parent.plot_settings.xlabel, fontweight=parent.plot_settings.font_weight)
-        self.right_label = self.right_axis.set_ylabel(parent.plot_settings.right_label, fontweight=parent.plot_settings.font_weight)
-        self.top_label = self.top_left_axis.set_xlabel(parent.plot_settings.top_label, fontweight=parent.plot_settings.font_weight)
-        self.left_label = self.ax.set_ylabel(parent.plot_settings.ylabel, fontweight=parent.plot_settings.font_weight)
+        self.bottom_label = self.ax.set_xlabel(
+            parent.plot_settings.xlabel,
+            fontweight=parent.plot_settings.font_weight)
+        self.right_label = self.right_axis.set_ylabel(
+            parent.plot_settings.right_label,
+            fontweight=parent.plot_settings.font_weight)
+        self.top_label = self.top_left_axis.set_xlabel(
+            parent.plot_settings.top_label,
+            fontweight=parent.plot_settings.font_weight)
+        self.left_label = self.ax.set_ylabel(
+            parent.plot_settings.ylabel,
+            fontweight=parent.plot_settings.font_weight)
         self.ax.set_yscale(parent.plot_settings.yscale)
         self.right_axis.set_yscale(parent.plot_settings.right_scale)
         self.top_left_axis.set_xscale(parent.plot_settings.top_scale)
@@ -56,9 +66,16 @@ class Canvas(FigureCanvas):
 
     def set_ticks(self, parent):
         """Set the ticks that are to be used in the graph."""
-        for axis in [self.top_right_axis, self.top_left_axis, self.ax, self.right_axis]:
-            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.major_tick_length, width=parent.plot_settings.major_tick_width, which="major")
-            axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.minor_tick_length, width=parent.plot_settings.minor_tick_width, which="minor")
+        for axis in [self.top_right_axis,
+                     self.top_left_axis, self.ax, self.right_axis]:
+            axis.tick_params(
+                direction=parent.plot_settings.tick_direction,
+                length=parent.plot_settings.major_tick_length,
+                width=parent.plot_settings.major_tick_width, which="major")
+            axis.tick_params(
+                direction=parent.plot_settings.tick_direction,
+                length=parent.plot_settings.minor_tick_length,
+                width=parent.plot_settings.minor_tick_width, which="minor")
             axis.tick_params(axis="x", which="minor")
             axis.tick_params(axis="y", which="minor")
             axis.minorticks_on()
@@ -76,9 +93,15 @@ class Canvas(FigureCanvas):
                 if parent.datadict[key].plot_y_position == "right":
                     right = True
             if not (top and bottom):
-                axis.tick_params(which="both", bottom=parent.plot_settings.tick_bottom, top=parent.plot_settings.tick_top)
+                axis.tick_params(
+                    which="both",
+                    bottom=parent.plot_settings.tick_bottom,
+                    top=parent.plot_settings.tick_top)
             if not (left and right):
-                axis.tick_params(which="both", left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
+                axis.tick_params(
+                    which="both",
+                    left=parent.plot_settings.tick_left,
+                    right=parent.plot_settings.tick_right)
 
     def set_style(self, parent):
         """Set the plot style."""
@@ -108,7 +131,8 @@ class Canvas(FigureCanvas):
     def set_color_cycle(self, parent):
         """Set the color cycle that will be used for the graphs."""
         cmap = parent.preferences.config["plot_color_cycle"]
-        reverse_dark = parent.preferences.config["plot_invert_color_cycle_dark"]
+        reverse_dark = parent.preferences.config[
+            "plot_invert_color_cycle_dark"]
         if Adw.StyleManager.get_default().get_dark() and reverse_dark:
             cmap += "_r"
         color_cycle = cycler(color=plt.get_cmap(cmap).colors)
@@ -117,9 +141,9 @@ class Canvas(FigureCanvas):
     def __call__(self, event):
         """
         The function is called when a user clicks on it.
-        If two clicks are performed close to each other, it registers as a double
-        click, and if these were on a specific item (e.g. the title) it triggers
-        a dialog to edit this item.
+        If two clicks are performed close to each other, it registers as a
+        double click, and if these were on a specific item (e.g. the title) it
+        triggers a dialog to edit this item.
 
         Unfortunately the GTK Doubleclick signal doesn"t work with matplotlib
         hence this custom function.
@@ -143,16 +167,18 @@ class Canvas(FigureCanvas):
         if self.top_label.contains(event)[0] and double_click:
             rename_label.open_rename_label_window(self.parent, self.top_label)
         if self.bottom_label.contains(event)[0] and double_click:
-            rename_label.open_rename_label_window(self.parent, self.bottom_label)
+            rename_label.open_rename_label_window(
+                self.parent, self.bottom_label)
         if self.left_label.contains(event)[0] and double_click:
             rename_label.open_rename_label_window(self.parent, self.left_label)
         if self.right_label.contains(event)[0] and double_click:
-            rename_label.open_rename_label_window(self.parent, self.right_label)
+            rename_label.open_rename_label_window(
+                self.parent, self.right_label)
 
     def _post_draw(self, _widget, context):
         """
-        Override with custom implementation of rubberband to allow for custom rubberband style
-        @param context: https://pycairo.readthedocs.io/en/latest/reference/context.html
+        Override with custom implementation of rubberband to allow for custom
+        rubberband style
         """
         if self._rubberband_rect is None:
             return

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -1,23 +1,26 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import time
-import matplotlib.pyplot as plt
 
-from gi.repository import Gtk, Adw
-from matplotlib.figure import Figure
-from matplotlib.backends.backend_gtk4cairo import FigureCanvas
 from cycler import cycler
 
-from . import rename_label, utilities
+from gi.repository import Adw
+
+from graphs import rename_label, utilities
+
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_gtk4cairo import FigureCanvas
+from matplotlib.figure import Figure
+
 
 class Canvas(FigureCanvas):
     """
     Create the graph widget
     """
-    def __init__(self, parent, xlabel='', ylabel='', yscale = 'log', title='', scale='linear', style = 'adwaita'):
+    def __init__(self, parent, xlabel='', ylabel='', yscale='log', title='', scale='linear', style='adwaita'):
         self.figure = Figure()
         self.figure.set_tight_layout(True)
         self.one_click_trigger = False
-        self.time_first_click  = 0
+        self.time_first_click = 0
         self.parent = parent
         self.mpl_connect('button_release_event', self)
         self.set_style(parent)
@@ -44,10 +47,10 @@ class Canvas(FigureCanvas):
         Set the properties that are related to the axes.
         """
         self.title = self.ax.set_title(parent.plot_settings.title)
-        self.bottom_label = self.ax.set_xlabel(parent.plot_settings.xlabel, fontweight = parent.plot_settings.font_weight)
-        self.right_label = self.right_axis.set_ylabel(parent.plot_settings.right_label, fontweight = parent.plot_settings.font_weight)
-        self.top_label = self.top_left_axis.set_xlabel(parent.plot_settings.top_label, fontweight = parent.plot_settings.font_weight)
-        self.left_label = self.ax.set_ylabel(parent.plot_settings.ylabel, fontweight = parent.plot_settings.font_weight)
+        self.bottom_label = self.ax.set_xlabel(parent.plot_settings.xlabel, fontweight=parent.plot_settings.font_weight)
+        self.right_label = self.right_axis.set_ylabel(parent.plot_settings.right_label, fontweight=parent.plot_settings.font_weight)
+        self.top_label = self.top_left_axis.set_xlabel(parent.plot_settings.top_label, fontweight=parent.plot_settings.font_weight)
+        self.left_label = self.ax.set_ylabel(parent.plot_settings.ylabel, fontweight=parent.plot_settings.font_weight)
         self.ax.set_yscale(parent.plot_settings.yscale)
         self.right_axis.set_yscale(parent.plot_settings.right_scale)
         self.top_left_axis.set_xscale(parent.plot_settings.top_scale)
@@ -62,8 +65,8 @@ class Canvas(FigureCanvas):
         for axis in [self.top_right_axis, self.top_left_axis, self.ax, self.right_axis]:
             axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.major_tick_length, width=parent.plot_settings.major_tick_width, which='major')
             axis.tick_params(direction=parent.plot_settings.tick_direction, length=parent.plot_settings.minor_tick_length, width=parent.plot_settings.minor_tick_width, which='minor')
-            axis.tick_params(axis='x',which='minor')
-            axis.tick_params(axis='y',which='minor')
+            axis.tick_params(axis='x', which='minor')
+            axis.tick_params(axis='y', which='minor')
             axis.minorticks_on()
             top = False
             bottom = False
@@ -79,9 +82,9 @@ class Canvas(FigureCanvas):
                 if parent.datadict[key].plot_Y_position == 'right':
                     right = True
             if not (top and bottom):
-                axis.tick_params(which = 'both', bottom=parent.plot_settings.tick_bottom, top=parent.plot_settings.tick_top)
+                axis.tick_params(which='both', bottom=parent.plot_settings.tick_bottom, top=parent.plot_settings.tick_top)
             if not (left and right):
-                axis.tick_params(which = 'both', left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
+                axis.tick_params(which='both', left=parent.plot_settings.tick_left, right=parent.plot_settings.tick_right)
 
     def set_style(self, parent):
         """
@@ -95,17 +98,17 @@ class Canvas(FigureCanvas):
             self.figure.patch.set_facecolor('#fafafa')
             text_color = 'black'
         params = {
-        'font.weight': parent.plot_settings.font_weight,
-        'font.sans-serif': parent.plot_settings.font_family,
-        'font.size': parent.plot_settings.font_size,
-        'axes.labelsize': parent.plot_settings.font_size,
-        'xtick.labelsize': parent.plot_settings.font_size,
-        'ytick.labelsize': parent.plot_settings.font_size,
-        'axes.titlesize': parent.plot_settings.font_size,
-        'legend.fontsize': parent.plot_settings.font_size,
-        'font.style': parent.plot_settings.font_style,
-        'mathtext.default': 'regular',
-        'axes.labelcolor' : text_color,
+            'font.weight': parent.plot_settings.font_weight,
+            'font.sans-serif': parent.plot_settings.font_family,
+            'font.size': parent.plot_settings.font_size,
+            'axes.labelsize': parent.plot_settings.font_size,
+            'xtick.labelsize': parent.plot_settings.font_size,
+            'ytick.labelsize': parent.plot_settings.font_size,
+            'axes.titlesize': parent.plot_settings.font_size,
+            'legend.fontsize': parent.plot_settings.font_size,
+            'font.style': parent.plot_settings.font_style,
+            'mathtext.default': 'regular',
+            'axes.labelcolor': text_color,
         }
         plt.style.use(parent.plot_settings.plot_style)
         plt.rcParams.update(params)
@@ -132,7 +135,7 @@ class Canvas(FigureCanvas):
         hence this custom function.
         """
         double_click = False
-        if self.one_click_trigger == False:
+        if not self.one_click_trigger:
             self.one_click_trigger = True
             self.time_first_click = time.time()
         else:
@@ -171,8 +174,6 @@ class Canvas(FigureCanvas):
         else:
             x0, y0, w, h = self._rubberband_rect
             lw *= self.device_pixel_ratio
-        x1 = x0 + w
-        y1 = y0 + h
 
         context.set_antialias(1)
         context.set_line_width(lw)
@@ -183,4 +184,3 @@ class Canvas(FigureCanvas):
         context.rectangle(x0, y0, w, h)
         context.set_source_rgba(ca.red, ca.green, ca.blue, 1)
         context.stroke()
-

--- a/src/colorpicker.py
+++ b/src/colorpicker.py
@@ -68,7 +68,8 @@ class ColorPicker(Gtk.Button):
     def set_css(self):
         self.provider = Gtk.CssProvider()
         context = self.get_style_context()
-        context.add_provider(self.provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        context.add_provider(
+            self.provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         rgba = utilities.create_rgba(*colors.to_rgba(self.color))
         self.set_rgba(rgba)
         self.set_rgba(self.get_rgba())

--- a/src/colorpicker.py
+++ b/src/colorpicker.py
@@ -9,26 +9,26 @@ class ColorPicker(Gtk.Button):
         super().__init__()
         self.parent = parent
         self.key = key
-        self.set_tooltip_text(_("Pick a color"))
+        self.set_tooltip_text(_('Pick a color'))
         self.color = color
-        self.add_css_class("flat")
+        self.add_css_class('flat')
         self.set_hexpand(False)
-        self.set_child(Gtk.Image.new_from_icon_name("color-picker-symbolic"))
+        self.set_child(Gtk.Image.new_from_icon_name('color-picker-symbolic'))
         self.get_child().set_pixel_size(20)
         
         press_gesture = Gtk.GestureClick()
-        press_gesture.connect("pressed", self.change_color)
+        press_gesture.connect('pressed', self.change_color)
         self.color_chooser = Gtk.ColorChooserWidget.new()
         self.color_chooser.set_use_alpha(False)
         self.color_chooser.show()
-        self.color_chooser.connect("color-activated", self.change_color)        
+        self.color_chooser.connect('color-activated', self.change_color)        
         self.color_chooser.add_controller(press_gesture)
             
         self.color_popover = Gtk.Popover()
         self.color_popover.set_parent(self)
         self.color_popover.set_child(self.color_chooser)
-        self.color_popover.connect("closed", self.change_color)
-        self.connect("clicked", self.on_click)
+        self.color_popover.connect('closed', self.change_color)
+        self.connect('clicked', self.on_click)
         self.set_css()
         self.color = self.get_color()
         parent.datadict[self.key].color = self.color

--- a/src/colorpicker.py
+++ b/src/colorpicker.py
@@ -39,31 +39,27 @@ class ColorPicker(Gtk.Button):
         self.color_chooser.set_rgba(color)
         self.update_color()
 
-    def on_click(self, button):
+    def on_click(self, _button):
         self.popover_active = True
         self.color_chooser.props.show_editor = False
         self.color_popover.popup()
 
-    def set_color(self, chooser, color, _=None):
+    def set_color(self, color):
         self.set_rgba(color)
         self.color = self.get_color()
         self.update_color()
         self.parent.datadict[self.key].color = self.color
         plotting_tools.refresh_plot(self.parent)
 
-    def change_color(self, *args):
-        self.set_color(self.color_chooser, self.get_rgba(), self.parent)
+    def change_color(self, *_args):
+        self.set_color(self.get_rgba())
 
     def get_rgba(self):
         return self.color_chooser.get_rgba()
 
-    def convert_rgba(self, rgba):
-        return (round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255), round(rgba.alpha * 255))
-
     def get_color(self):
-        color_rgba = self.convert_rgba(self.get_rgba())
-        color_hex = '#{:02x}{:02x}{:02x}'.format(*color_rgba)
-        return color_hex
+        color_rgba = self.get_rgba()
+        return utilities.rgba_to_hex(color_rgba)
 
     def update_color(self):
         css = f'button {{ color: {self.get_rgba().to_string()}; }}'

--- a/src/colorpicker.py
+++ b/src/colorpicker.py
@@ -11,26 +11,26 @@ class ColorPicker(Gtk.Button):
         super().__init__()
         self.parent = parent
         self.key = key
-        self.set_tooltip_text('Pick a color')
+        self.set_tooltip_text("Pick a color")
         self.color = color
-        self.add_css_class('flat')
+        self.add_css_class("flat")
         self.set_hexpand(False)
-        self.set_child(Gtk.Image.new_from_icon_name('color-picker-symbolic'))
+        self.set_child(Gtk.Image.new_from_icon_name("color-picker-symbolic"))
         self.get_child().set_pixel_size(20)
 
         press_gesture = Gtk.GestureClick()
-        press_gesture.connect('pressed', self.change_color)
+        press_gesture.connect("pressed", self.change_color)
         self.color_chooser = Gtk.ColorChooserWidget.new()
         self.color_chooser.set_use_alpha(False)
         self.color_chooser.show()
-        self.color_chooser.connect('color-activated', self.change_color)
+        self.color_chooser.connect("color-activated", self.change_color)
         self.color_chooser.add_controller(press_gesture)
 
         self.color_popover = Gtk.Popover()
         self.color_popover.set_parent(self)
         self.color_popover.set_child(self.color_chooser)
-        self.color_popover.connect('closed', self.change_color)
-        self.connect('clicked', self.on_click)
+        self.color_popover.connect("closed", self.change_color)
+        self.connect("clicked", self.on_click)
         self.set_css()
         self.color = self.get_color()
         parent.datadict[self.key].color = self.color
@@ -62,7 +62,7 @@ class ColorPicker(Gtk.Button):
         return utilities.rgba_to_hex(color_rgba)
 
     def update_color(self):
-        css = f'button {{ color: {self.get_rgba().to_string()}; }}'
+        css = f"button {{ color: {self.get_rgba().to_string()}; }}"
         self.provider.load_from_data(css.encode())
 
     def set_css(self):

--- a/src/colorpicker.py
+++ b/src/colorpicker.py
@@ -1,29 +1,31 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Gtk
+
+from graphs import plotting_tools, utilities
+
 from matplotlib import colors
 
-from . import plotting_tools, utilities
 
 class ColorPicker(Gtk.Button):
     def __init__(self, color, key, parent):
         super().__init__()
         self.parent = parent
         self.key = key
-        self.set_tooltip_text(_('Pick a color'))
+        self.set_tooltip_text('Pick a color')
         self.color = color
         self.add_css_class('flat')
         self.set_hexpand(False)
         self.set_child(Gtk.Image.new_from_icon_name('color-picker-symbolic'))
         self.get_child().set_pixel_size(20)
-        
+
         press_gesture = Gtk.GestureClick()
         press_gesture.connect('pressed', self.change_color)
         self.color_chooser = Gtk.ColorChooserWidget.new()
         self.color_chooser.set_use_alpha(False)
         self.color_chooser.show()
-        self.color_chooser.connect('color-activated', self.change_color)        
+        self.color_chooser.connect('color-activated', self.change_color)
         self.color_chooser.add_controller(press_gesture)
-            
+
         self.color_popover = Gtk.Popover()
         self.color_popover.set_parent(self)
         self.color_popover.set_child(self.color_chooser)
@@ -32,7 +34,6 @@ class ColorPicker(Gtk.Button):
         self.set_css()
         self.color = self.get_color()
         parent.datadict[self.key].color = self.color
-
 
     def set_rgba(self, color):
         self.color_chooser.set_rgba(color)
@@ -43,7 +44,7 @@ class ColorPicker(Gtk.Button):
         self.color_chooser.props.show_editor = False
         self.color_popover.popup()
 
-    def set_color(self, chooser, color, _ = None):
+    def set_color(self, chooser, color, _=None):
         self.set_rgba(color)
         self.color = self.get_color()
         self.update_color()
@@ -57,7 +58,7 @@ class ColorPicker(Gtk.Button):
         return self.color_chooser.get_rgba()
 
     def convert_rgba(self, rgba):
-        return (round(rgba.red*255), round(rgba.green*255), round(rgba.blue*255), round(rgba.alpha*255))
+        return (round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255), round(rgba.alpha * 255))
 
     def get_color(self):
         color_rgba = self.convert_rgba(self.get_rgba())
@@ -76,4 +77,3 @@ class ColorPicker(Gtk.Button):
         self.set_rgba(rgba)
         self.set_rgba(self.get_rgba())
         self.update_color()
-

--- a/src/data.py
+++ b/src/data.py
@@ -31,17 +31,28 @@ class Data:
         self.set_data_properties(parent, import_settings)
 
     def set_data_properties(self, parent, import_settings):
-        self.plot_y_position = parent.preferences.config["plot_Y_position"]
-        self.plot_x_position = parent.preferences.config["plot_X_position"]
-        self.linestyle_selected = parent.preferences.config["plot_selected_linestyle"]
-        self.linestyle_unselected = parent.preferences.config["plot_unselected_linestyle"]
-        self.selected_line_thickness = parent.preferences.config["selected_linewidth"]
-        self.unselected_line_thickness = parent.preferences.config["unselected_linewidth"]
-        self.selected_markers = parent.preferences.config["plot_selected_markers"]
-        self.unselected_markers = parent.preferences.config["plot_unselected_markers"]
-        self.selected_marker_size = parent.preferences.config["plot_selected_marker_size"]
-        self.unselected_marker_size = parent.preferences.config["plot_unselected_marker_size"]
-        if import_settings.name != "" and import_settings.mode == ImportMode.SINGLE:
+        self.plot_y_position = parent.preferences.config[
+            "plot_Y_position"]
+        self.plot_x_position = parent.preferences.config[
+            "plot_X_position"]
+        self.linestyle_selected = parent.preferences.config[
+            "plot_selected_linestyle"]
+        self.linestyle_unselected = parent.preferences.config[
+            "plot_unselected_linestyle"]
+        self.selected_line_thickness = parent.preferences.config[
+            "selected_linewidth"]
+        self.unselected_line_thickness = parent.preferences.config[
+            "unselected_linewidth"]
+        self.selected_markers = parent.preferences.config[
+            "plot_selected_markers"]
+        self.unselected_markers = parent.preferences.config[
+            "plot_unselected_markers"]
+        self.selected_marker_size = parent.preferences.config[
+            "plot_selected_marker_size"]
+        self.unselected_marker_size = parent.preferences.config[
+            "plot_unselected_marker_size"]
+        if import_settings.name != "" \
+                and import_settings.mode == ImportMode.SINGLE:
             filename = import_settings.name
         else:
             filename = import_settings.path.split("/")[-1]

--- a/src/data.py
+++ b/src/data.py
@@ -7,19 +7,19 @@ from graphs.misc import ImportMode, ImportSettings
 
 class Data:
     def __init__(self, parent, xdata, ydata, import_settings=None):
-        self.filename = ''
-        self.linestyle_selected = ''
-        self.linestyle_unselected = ''
+        self.filename = ""
+        self.linestyle_selected = ""
+        self.linestyle_unselected = ""
         self.selected_line_thickness = float(0)
         self.unselected_line_thickness = float(0)
-        self.selected_markers = ''
-        self.unselected_markers = ''
+        self.selected_markers = ""
+        self.unselected_markers = ""
         self.selected_marker_size = float(0)
         self.unselected_marker_size = float(0)
-        self.plot_y_position = 'left'
-        self.plot_x_position = 'bottom'
+        self.plot_y_position = "left"
+        self.plot_x_position = "bottom"
         self.selected = True
-        self.color = ''
+        self.color = ""
         self.xdata = xdata
         self.ydata = ydata
         self.clipboard_pos = 0
@@ -31,19 +31,19 @@ class Data:
         self.set_data_properties(parent, import_settings)
 
     def set_data_properties(self, parent, import_settings):
-        self.plot_y_position = parent.preferences.config['plot_Y_position']
-        self.plot_x_position = parent.preferences.config['plot_X_position']
-        self.linestyle_selected = parent.preferences.config['plot_selected_linestyle']
-        self.linestyle_unselected = parent.preferences.config['plot_unselected_linestyle']
-        self.selected_line_thickness = parent.preferences.config['selected_linewidth']
-        self.unselected_line_thickness = parent.preferences.config['unselected_linewidth']
-        self.selected_markers = parent.preferences.config['plot_selected_markers']
-        self.unselected_markers = parent.preferences.config['plot_unselected_markers']
-        self.selected_marker_size = parent.preferences.config['plot_selected_marker_size']
-        self.unselected_marker_size = parent.preferences.config['plot_unselected_marker_size']
-        if import_settings.name != '' and import_settings.mode == ImportMode.SINGLE:
+        self.plot_y_position = parent.preferences.config["plot_Y_position"]
+        self.plot_x_position = parent.preferences.config["plot_X_position"]
+        self.linestyle_selected = parent.preferences.config["plot_selected_linestyle"]
+        self.linestyle_unselected = parent.preferences.config["plot_unselected_linestyle"]
+        self.selected_line_thickness = parent.preferences.config["selected_linewidth"]
+        self.unselected_line_thickness = parent.preferences.config["unselected_linewidth"]
+        self.selected_markers = parent.preferences.config["plot_selected_markers"]
+        self.unselected_markers = parent.preferences.config["plot_unselected_markers"]
+        self.selected_marker_size = parent.preferences.config["plot_selected_marker_size"]
+        self.unselected_marker_size = parent.preferences.config["plot_unselected_marker_size"]
+        if import_settings.name != "" and import_settings.mode == ImportMode.SINGLE:
             filename = import_settings.name
         else:
-            filename = import_settings.path.split('/')[-1]
+            filename = import_settings.path.split("/")[-1]
             filename = os.path.splitext(filename)[0]
         self.filename = filename

--- a/src/data.py
+++ b/src/data.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import uuid
 import os
-from . import graphs, utilities
-from .misc import ImportSettings, ImportMode
+import uuid
 
-class Data:  
-    def __init__(self, parent, xdata, ydata, import_settings = None):
+from graphs.misc import ImportMode, ImportSettings
+
+
+class Data:
+    def __init__(self, parent, xdata, ydata, import_settings=None):
         self.filename = ''
         self.linestyle_selected = ''
         self.linestyle_unselected = ''
@@ -28,7 +29,7 @@ class Data:
         if import_settings is None:
             import_settings = ImportSettings(parent)
         self.set_data_properties(parent, import_settings)
-                    
+
     def set_data_properties(self, parent, import_settings):
         self.plot_Y_position = parent.preferences.config['plot_Y_position']
         self.plot_X_position = parent.preferences.config['plot_X_position']
@@ -45,5 +46,4 @@ class Data:
         else:
             filename = import_settings.path.split('/')[-1]
             filename = os.path.splitext(filename)[0]
-        self.filename = filename          
-       
+        self.filename = filename

--- a/src/data.py
+++ b/src/data.py
@@ -6,19 +6,19 @@ from .misc import ImportSettings, ImportMode
 
 class Data:  
     def __init__(self, parent, xdata, ydata, import_settings = None):
-        self.filename = ""
-        self.linestyle_selected = ""
-        self.linestyle_unselected = ""
+        self.filename = ''
+        self.linestyle_selected = ''
+        self.linestyle_unselected = ''
         self.selected_line_thickness = float(0)
         self.unselected_line_thickness = float(0)
-        self.selected_markers = ""
-        self.unselected_markers = ""
+        self.selected_markers = ''
+        self.unselected_markers = ''
         self.selected_marker_size = float(0)
         self.unselected_marker_size = float(0)
-        self.plot_Y_position = "left"
-        self.plot_X_position = "bottom"
+        self.plot_Y_position = 'left'
+        self.plot_X_position = 'bottom'
         self.selected = True
-        self.color = ""
+        self.color = ''
         self.xdata = xdata
         self.ydata = ydata
         self.clipboard_pos = 0
@@ -30,20 +30,20 @@ class Data:
         self.set_data_properties(parent, import_settings)
                     
     def set_data_properties(self, parent, import_settings):
-        self.plot_Y_position = parent.preferences.config["plot_Y_position"]
-        self.plot_X_position = parent.preferences.config["plot_X_position"]    
-        self.linestyle_selected = parent.preferences.config["plot_selected_linestyle"]
-        self.linestyle_unselected = parent.preferences.config["plot_unselected_linestyle"]
-        self.selected_line_thickness = parent.preferences.config["selected_linewidth"]
-        self.unselected_line_thickness = parent.preferences.config["unselected_linewidth"]
-        self.selected_markers = parent.preferences.config["plot_selected_markers"]
-        self.unselected_markers = parent.preferences.config["plot_unselected_markers"]
-        self.selected_marker_size = parent.preferences.config["plot_selected_marker_size"]
-        self.unselected_marker_size = parent.preferences.config["plot_unselected_marker_size"]        
-        if import_settings.name != "" and import_settings.mode == ImportMode.SINGLE:
+        self.plot_Y_position = parent.preferences.config['plot_Y_position']
+        self.plot_X_position = parent.preferences.config['plot_X_position']
+        self.linestyle_selected = parent.preferences.config['plot_selected_linestyle']
+        self.linestyle_unselected = parent.preferences.config['plot_unselected_linestyle']
+        self.selected_line_thickness = parent.preferences.config['selected_linewidth']
+        self.unselected_line_thickness = parent.preferences.config['unselected_linewidth']
+        self.selected_markers = parent.preferences.config['plot_selected_markers']
+        self.unselected_markers = parent.preferences.config['plot_unselected_markers']
+        self.selected_marker_size = parent.preferences.config['plot_selected_marker_size']
+        self.unselected_marker_size = parent.preferences.config['plot_unselected_marker_size']
+        if import_settings.name != '' and import_settings.mode == ImportMode.SINGLE:
             filename = import_settings.name
         else:
-            filename = import_settings.path.split("/")[-1]
+            filename = import_settings.path.split('/')[-1]
             filename = os.path.splitext(filename)[0]
         self.filename = filename          
        

--- a/src/data.py
+++ b/src/data.py
@@ -16,8 +16,8 @@ class Data:
         self.unselected_markers = ''
         self.selected_marker_size = float(0)
         self.unselected_marker_size = float(0)
-        self.plot_Y_position = 'left'
-        self.plot_X_position = 'bottom'
+        self.plot_y_position = 'left'
+        self.plot_x_position = 'bottom'
         self.selected = True
         self.color = ''
         self.xdata = xdata
@@ -31,8 +31,8 @@ class Data:
         self.set_data_properties(parent, import_settings)
 
     def set_data_properties(self, parent, import_settings):
-        self.plot_Y_position = parent.preferences.config['plot_Y_position']
-        self.plot_X_position = parent.preferences.config['plot_X_position']
+        self.plot_y_position = parent.preferences.config['plot_Y_position']
+        self.plot_x_position = parent.preferences.config['plot_X_position']
         self.linestyle_selected = parent.preferences.config['plot_selected_linestyle']
         self.linestyle_unselected = parent.preferences.config['plot_unselected_linestyle']
         self.selected_line_thickness = parent.preferences.config['selected_linewidth']

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -8,9 +8,9 @@ from .data import Data
 
 def save_project(self, path):
     project_data = dict()
-    project_data["plot_settings"] = self.plot_settings
-    project_data["data"] = self.datadict
-    project_data["version"] = self.version
+    project_data['plot_settings'] = self.plot_settings
+    project_data['data'] = self.datadict
+    project_data['version'] = self.version
     with open(path, 'wb') as f:
         pickle.dump(project_data, f)
 
@@ -18,14 +18,14 @@ def load_project(self, files):
     new_files = []
     for file in files:
         file_path = file.peek_path()
-        filename = file_path.split("/")[-1]
+        filename = file_path.split('/')[-1]
         new_files.append(file_path)
     for key in self.datadict.copy():
         graphs.delete(self, key)
     with open(file_path, 'rb') as f:
         project =  pickle.load(f)
-    project_datadict = project["data"]
-    new_plot_settings = project["plot_settings"]
+    project_datadict = project['data']
+    new_plot_settings = project['plot_settings']
     self.plot_settings = new_plot_settings
     graphs.set_attributes(new_plot_settings, self.plot_settings)
     graphs.create_data_from_project(self, project_datadict)
@@ -43,17 +43,17 @@ def save_file(self, path):
             ydata = item.ydata
         filename = path
         array = numpy.stack([xdata, ydata], axis=1)
-        numpy.savetxt(str(filename), array, delimiter="\t")
+        numpy.savetxt(str(filename), array, delimiter='\t')
     elif len(self.datadict) > 1:
         for key, item in self.datadict.items():
             xdata = item.xdata
             ydata = item.ydata
             filename = item.filename
             array = numpy.stack([xdata, ydata], axis=1)
-            if os.path.exists(f"{path}/{filename}.txt"):
-                numpy.savetxt(str(path + "/" + filename) + " (copy).txt", array, delimiter="\t")
+            if os.path.exists(f'{path}/{filename}.txt'):
+                numpy.savetxt(str(path + '/' + filename) + ' (copy).txt', array, delimiter='\t')
             else:
-                numpy.savetxt(str(path + "/" + filename) + ".txt", array, delimiter="\t")
+                numpy.savetxt(str(path + '/' + filename) + '.txt', array, delimiter='\t')
 
 def get_data(self, import_settings):
     data_array = [[], []]
@@ -65,7 +65,7 @@ def get_data(self, import_settings):
             if i > import_settings.skip_rows:
                 line = line.strip()
                 data_line = re.split(str(import_settings.delimiter), line)
-                if import_settings.separator == ",":
+                if import_settings.separator == ',':
                     for index, value in enumerate(data_line):
                         data_line[index] = swap(value)
                 try:
@@ -82,12 +82,12 @@ def get_data(self, import_settings):
                         #The reasoning is that some people use tabs for the headers, but
                         #e.g. commas for the data
                         try:
-                            headers = re.split("\s{2,}", line)
+                            headers = re.split('\s{2,}', line)
                             self.plot_settings.xlabel = headers[import_settings.column_x]
                             self.plot_settings.ylabel = headers[import_settings.column_y]
                         except IndexError:
                             try:
-                                headers = re.split(import_settings["delimiter"], line)
+                                headers = re.split(import_settings['delimiter'], line)
                                 self.plot_settings.xlabel = headers[import_settings.column_x]
                                 self.plot_settings.ylabel = headers[import_settings.column_y]
                             #If neither heuristic works, we just skip the headers

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -3,7 +3,7 @@ import os
 import pickle
 import re
 
-from graphs import graphs, plotting_tools, utilities
+from graphs import graphs, plotting_tools, ui, utilities
 from graphs.data import Data
 
 import numpy
@@ -11,10 +11,10 @@ import numpy
 
 def save_project(self, path):
     project_data = {}
-    project_data['plot_settings'] = self.plot_settings
-    project_data['data'] = self.datadict
-    project_data['version'] = self.version
-    with open(path, 'wb') as file:
+    project_data["plot_settings"] = self.plot_settings
+    project_data["data"] = self.datadict
+    project_data["version"] = self.version
+    with open(path, "wb") as file:
         pickle.dump(project_data, file)
 
 
@@ -25,10 +25,10 @@ def load_project(self, files):
         new_files.append(file_path)
     for key in self.datadict.copy():
         graphs.delete(self, key)
-    with open(file_path, 'rb') as file:
+    with open(file_path, "rb") as file:
         project = pickle.load(file)
-    project_datadict = project['data']
-    new_plot_settings = project['plot_settings']
+    project_datadict = project["data"]
+    new_plot_settings = project["plot_settings"]
     self.plot_settings = new_plot_settings
     graphs.set_attributes(new_plot_settings, self.plot_settings)
     graphs.create_data_from_project(self, project_datadict)
@@ -37,7 +37,8 @@ def load_project(self, files):
     plotting_tools.reload_plot(self)
     for key, item in self.item_rows.items():
         item.check_button.set_active(True)
-    graphs.toggle_data(None, self)
+    plotting_tools.refresh_plot(self)
+    ui.enable_data_dependent_buttons(self, utilities.get_selected_keys(self))
 
 
 def save_file(self, path):
@@ -47,30 +48,30 @@ def save_file(self, path):
             ydata = item.ydata
         filename = path
         array = numpy.stack([xdata, ydata], axis=1)
-        numpy.savetxt(str(filename), array, delimiter='\t')
+        numpy.savetxt(str(filename), array, delimiter="\t")
     elif len(self.datadict) > 1:
         for _key, item in self.datadict.items():
             xdata = item.xdata
             ydata = item.ydata
             filename = item.filename
             array = numpy.stack([xdata, ydata], axis=1)
-            if os.path.exists(f'{path}/{filename}.txt'):
-                numpy.savetxt(str(path + '/' + filename) + ' (copy).txt', array, delimiter='\t')
+            if os.path.exists(f"{path}/{filename}.txt"):
+                numpy.savetxt(str(path + "/" + filename) + " (copy).txt", array, delimiter="\t")
             else:
-                numpy.savetxt(str(path + '/' + filename) + '.txt', array, delimiter='\t')
+                numpy.savetxt(str(path + "/" + filename) + ".txt", array, delimiter="\t")
 
 
 def get_data(self, import_settings):
     data_array = [[], []]
     i = 0
     path = import_settings.path
-    with open(path, 'r', encoding='utf-8') as file:
+    with open(path, "r", encoding="utf-8") as file:
         for line in file:
             i += 1
             if i > import_settings.skip_rows:
                 line = line.strip()
                 data_line = re.split(str(import_settings.delimiter), line)
-                if import_settings.separator == ',':
+                if import_settings.separator == ",":
                     for index, value in enumerate(data_line):
                         data_line[index] = utilities.swap(value)
                 try:
@@ -82,17 +83,17 @@ def get_data(self, import_settings):
                 except ValueError:
                     if import_settings.guess_headers:
                         # By default it will check for headers using at least two whitespaces
-                        # as delimiter (often tabs), but if that doesn't work it will try
+                        # as delimiter (often tabs), but if that doesn"t work it will try
                         # the same delimiter as used for the data import itself
                         # The reasoning is that some people use tabs for the headers, but
                         # e.g. commas for the data
                         try:
-                            headers = re.split('\\s{2,}', line)
+                            headers = re.split("\\s{2,}", line)
                             self.plot_settings.xlabel = headers[import_settings.column_x]
                             self.plot_settings.ylabel = headers[import_settings.column_y]
                         except IndexError:
                             try:
-                                headers = re.split(import_settings['delimiter'], line)
+                                headers = re.split(import_settings["delimiter"], line)
                                 self.plot_settings.xlabel = headers[import_settings.column_x]
                                 self.plot_settings.ylabel = headers[import_settings.column_y]
                             # If neither heuristic works, we just skip the headers

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -1,29 +1,32 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import numpy
-import re
+import os
 import pickle
+import re
 
-from . import graphs, plotting_tools
-from .data import Data
+from graphs import graphs, plotting_tools, utilities
+from graphs.data import Data
+
+import numpy
+
 
 def save_project(self, path):
-    project_data = dict()
+    project_data = {}
     project_data['plot_settings'] = self.plot_settings
     project_data['data'] = self.datadict
     project_data['version'] = self.version
     with open(path, 'wb') as f:
         pickle.dump(project_data, f)
 
+
 def load_project(self, files):
     new_files = []
     for file in files:
         file_path = file.peek_path()
-        filename = file_path.split('/')[-1]
         new_files.append(file_path)
     for key in self.datadict.copy():
         graphs.delete(self, key)
     with open(file_path, 'rb') as f:
-        project =  pickle.load(f)
+        project = pickle.load(f)
     project_datadict = project['data']
     new_plot_settings = project['plot_settings']
     self.plot_settings = new_plot_settings
@@ -35,6 +38,7 @@ def load_project(self, files):
     for key, item in self.item_rows.items():
         item.check_button.set_active(True)
     graphs.toggle_data(None, self)
+
 
 def save_file(self, path):
     if len(self.datadict) == 1:
@@ -55,6 +59,7 @@ def save_file(self, path):
             else:
                 numpy.savetxt(str(path + '/' + filename) + '.txt', array, delimiter='\t')
 
+
 def get_data(self, import_settings):
     data_array = [[], []]
     i = 0
@@ -67,22 +72,22 @@ def get_data(self, import_settings):
                 data_line = re.split(str(import_settings.delimiter), line)
                 if import_settings.separator == ',':
                     for index, value in enumerate(data_line):
-                        data_line[index] = swap(value)
+                        data_line[index] = utilities.swap(value)
                 try:
                     data_array[0].append(float(data_line[import_settings.column_x]))
                     data_array[1].append(float(data_line[import_settings.column_y]))
 
-                #If it finds non-numbers, it will raise a ValueError, this is the cue to
-                #start looking for headers
+                # If it finds non-numbers, it will raise a ValueError, this is the cue to
+                # start looking for headers
                 except ValueError:
                     if import_settings.guess_headers:
-                        #By default it will check for headers using at least two whitespaces
-                        #as delimiter (often tabs), but if that doesn't work it will try
-                        #the same delimiter as used for the data import itself
-                        #The reasoning is that some people use tabs for the headers, but
-                        #e.g. commas for the data
+                        # By default it will check for headers using at least two whitespaces
+                        # as delimiter (often tabs), but if that doesn't work it will try
+                        # the same delimiter as used for the data import itself
+                        # The reasoning is that some people use tabs for the headers, but
+                        # e.g. commas for the data
                         try:
-                            headers = re.split('\s{2,}', line)
+                            headers = re.split('\\s{2,}', line)
                             self.plot_settings.xlabel = headers[import_settings.column_x]
                             self.plot_settings.ylabel = headers[import_settings.column_y]
                         except IndexError:
@@ -90,9 +95,8 @@ def get_data(self, import_settings):
                                 headers = re.split(import_settings['delimiter'], line)
                                 self.plot_settings.xlabel = headers[import_settings.column_x]
                                 self.plot_settings.ylabel = headers[import_settings.column_y]
-                            #If neither heuristic works, we just skip the headers
+                            # If neither heuristic works, we just skip the headers
                             except IndexError:
                                 pass
     data = Data(self, data_array[0], data_array[1], import_settings)
     return data
-

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -56,9 +56,11 @@ def save_file(self, path):
             filename = item.filename
             array = numpy.stack([xdata, ydata], axis=1)
             if os.path.exists(f"{path}/{filename}.txt"):
-                numpy.savetxt(str(path + "/" + filename) + " (copy).txt", array, delimiter="\t")
+                numpy.savetxt(str(path + "/" + filename) + " (copy).txt",
+                              array, delimiter="\t")
             else:
-                numpy.savetxt(str(path + "/" + filename) + ".txt", array, delimiter="\t")
+                numpy.savetxt(str(path + "/" + filename) + ".txt", array,
+                              delimiter="\t")
 
 
 def get_data(self, import_settings):
@@ -75,28 +77,36 @@ def get_data(self, import_settings):
                     for index, value in enumerate(data_line):
                         data_line[index] = utilities.swap(value)
                 try:
-                    data_array[0].append(float(data_line[import_settings.column_x]))
-                    data_array[1].append(float(data_line[import_settings.column_y]))
+                    data_array[0].append(float(data_line[
+                        import_settings.column_x]))
+                    data_array[1].append(float(data_line[
+                        import_settings.column_y]))
 
-                # If it finds non-numbers, it will raise a ValueError, this is the cue to
-                # start looking for headers
+                # If it finds non-numbers, it will raise a ValueError,
+                # this is the cue to start looking for headers
                 except ValueError:
                     if import_settings.guess_headers:
-                        # By default it will check for headers using at least two whitespaces
-                        # as delimiter (often tabs), but if that doesn"t work it will try
-                        # the same delimiter as used for the data import itself
-                        # The reasoning is that some people use tabs for the headers, but
-                        # e.g. commas for the data
+                        # By default it will check for headers using at least
+                        # two whitespaces as delimiter (often tabs), but if
+                        # that doesn"t work it will try the same delimiter as
+                        # used for the data import itself The reasoning is that
+                        # some people use tabs for the headers, but e.g. commas
+                        # for the data
                         try:
                             headers = re.split("\\s{2,}", line)
-                            self.plot_settings.xlabel = headers[import_settings.column_x]
-                            self.plot_settings.ylabel = headers[import_settings.column_y]
+                            self.plot_settings.xlabel = headers[
+                                import_settings.column_x]
+                            self.plot_settings.ylabel = headers[
+                                import_settings.column_y]
                         except IndexError:
                             try:
-                                headers = re.split(import_settings["delimiter"], line)
-                                self.plot_settings.xlabel = headers[import_settings.column_x]
-                                self.plot_settings.ylabel = headers[import_settings.column_y]
-                            # If neither heuristic works, we just skip the headers
+                                headers = re.split(
+                                    import_settings["delimiter"], line)
+                                self.plot_settings.xlabel = headers[
+                                    import_settings.column_x]
+                                self.plot_settings.ylabel = headers[
+                                    import_settings.column_y]
+                            # If neither heuristic works, we just skip headers
                             except IndexError:
                                 pass
     data = Data(self, data_array[0], data_array[1], import_settings)

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -42,14 +42,14 @@ def load_project(self, files):
 
 def save_file(self, path):
     if len(self.datadict) == 1:
-        for key, item in self.datadict.items():
+        for _key, item in self.datadict.items():
             xdata = item.xdata
             ydata = item.ydata
         filename = path
         array = numpy.stack([xdata, ydata], axis=1)
         numpy.savetxt(str(filename), array, delimiter='\t')
     elif len(self.datadict) > 1:
-        for key, item in self.datadict.items():
+        for _key, item in self.datadict.items():
             xdata = item.xdata
             ydata = item.ydata
             filename = item.filename
@@ -64,7 +64,7 @@ def get_data(self, import_settings):
     data_array = [[], []]
     i = 0
     path = import_settings.path
-    with (open(path, 'r')) as file:
+    with open(path, 'r', encoding='utf-8') as file:
         for line in file:
             i += 1
             if i > import_settings.skip_rows:

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -14,8 +14,8 @@ def save_project(self, path):
     project_data['plot_settings'] = self.plot_settings
     project_data['data'] = self.datadict
     project_data['version'] = self.version
-    with open(path, 'wb') as f:
-        pickle.dump(project_data, f)
+    with open(path, 'wb') as file:
+        pickle.dump(project_data, file)
 
 
 def load_project(self, files):
@@ -25,8 +25,8 @@ def load_project(self, files):
         new_files.append(file_path)
     for key in self.datadict.copy():
         graphs.delete(self, key)
-    with open(file_path, 'rb') as f:
-        project = pickle.load(f)
+    with open(file_path, 'rb') as file:
+        project = pickle.load(file)
     project_datadict = project['data']
     new_plot_settings = project['plot_settings']
     self.plot_settings = new_plot_settings

--- a/src/graphs.in
+++ b/src/graphs.in
@@ -22,29 +22,30 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+"""Main graphs module."""
 
-import os
-import sys
-import signal
-import locale
 import gettext
+import locale
+import os
+import signal
+import sys
 
 VERSION = '@version@'
-project = '@project@'
-pkgdatadir = '@pkgdatadir@'
-localedir = '@localedir@'
-copyright = '@copyright@'
-appid = '@appid@'
-name = '@name@'
-website = '@website@'
-issues = '@issues@'
-author = '@author@'
+PROJECT = '@project@'
+PKGDATADIR = '@pkgdatadir@'
+LOCALEDIR = '@localedir@'
+COPYRIGHT = '@copyright@'
+APPID = '@appid@'
+NAME = '@name@'
+WEBSITE = '@website@'
+ISSUES = '@issues@'
+AUTHOR = '@author@'
 
-sys.path.insert(1, pkgdatadir)
+sys.path.insert(1, PKGDATADIR)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
-locale.bindtextdomain(project, localedir)
-locale.textdomain(project)
-gettext.install(project, localedir)
+locale.bindtextdomain(PROJECT, LOCALEDIR)
+locale.textdomain(PROJECT)
+gettext.install(PROJECT, LOCALEDIR)
 
 if __name__ == '__main__':
     import gi
@@ -53,9 +54,10 @@ if __name__ == '__main__':
     gi.require_version('Gtk', '4.0')
 
     from gi.repository import Gio
-    resource = Gio.Resource.load(os.path.join(pkgdatadir, '@appid@.gresource'))
+    resource = Gio.Resource.load(os.path.join(PKGDATADIR, '@appid@.gresource'))
     resource._register()
 
-    from @project@ import main
-    sys.exit(main.main(VERSION, appid, name, copyright, website, issues, author))
+    args = [VERSION, APPID, NAME, COPYRIGHT, WEBSITE, ISSUES, AUTHOR]
 
+    from graphs import main
+    sys.exit(main.main(args))

--- a/src/graphs.in
+++ b/src/graphs.in
@@ -30,16 +30,16 @@ import os
 import signal
 import sys
 
-VERSION = '@version@'
-PROJECT = '@project@'
-PKGDATADIR = '@pkgdatadir@'
-LOCALEDIR = '@localedir@'
-COPYRIGHT = '@copyright@'
-APPID = '@appid@'
-NAME = '@name@'
-WEBSITE = '@website@'
-ISSUES = '@issues@'
-AUTHOR = '@author@'
+VERSION = "@version@"
+PROJECT = "@project@"
+PKGDATADIR = "@pkgdatadir@"
+LOCALEDIR = "@localedir@"
+COPYRIGHT = "@copyright@"
+APPID = "@appid@"
+NAME = "@name@"
+WEBSITE = "@website@"
+ISSUES = "@issues@"
+AUTHOR = "@author@"
 
 sys.path.insert(1, PKGDATADIR)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
@@ -47,14 +47,14 @@ locale.bindtextdomain(PROJECT, LOCALEDIR)
 locale.textdomain(PROJECT)
 gettext.install(PROJECT, LOCALEDIR)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import gi
 
-    gi.require_version('Adw', '1')
-    gi.require_version('Gtk', '4.0')
+    gi.require_version("Adw", "1")
+    gi.require_version("Gtk", "4.0")
 
     from gi.repository import Gio
-    resource = Gio.Resource.load(os.path.join(PKGDATADIR, '@appid@.gresource'))
+    resource = Gio.Resource.load(os.path.join(PKGDATADIR, "@appid@.gresource"))
     resource._register()
 
     args = [VERSION, APPID, NAME, COPYRIGHT, WEBSITE, ISSUES, AUTHOR]

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -21,9 +21,9 @@ def open_selection_from_dict(self):
                 marker = item.unselected_markers
                 marker_size = item.unselected_marker_size
             color = self.item_rows[key].color_picker.color
-            y_axis = item.plot_Y_position
-            x_axis = item.plot_X_position
-            plotting_tools.plot_figure(self, self.canvas, item.xdata, item.ydata, item.filename, linewidth, linestyle, color, marker, marker_size, y_axis, x_axis)
+            y_axis = item.plot_y_position
+            x_axis = item.plot_x_position
+            plotting_tools.plot_figure(self, self.canvas, item.xdata, item.ydata, item.filename, linewidth=linewidth, linestyle=linestyle, color=color, marker=marker, marker_size=marker_size, y_axis=y_axis, x_axis=x_axis)
 
 
 def open_files(self, files, import_settings):
@@ -59,16 +59,16 @@ def open_files(self, files, import_settings):
                                 self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Item \'{item.filename}\' already exists'))
                                 return
                             elif handle_duplicates == 'Override existing items':
-                                y_axis = item.plot_Y_position
-                                x_axis = item.plot_X_position
+                                y_axis = item.plot_y_position
+                                x_axis = item.plot_x_position
                                 self.datadict[key] = item
                                 plotting_tools.reload_plot(self)
                                 return
-                y_axis = item.plot_Y_position
-                x_axis = item.plot_X_position
+                y_axis = item.plot_y_position
+                x_axis = item.plot_x_position
                 self.datadict[item.key] = item
                 item.color = plotting_tools.get_next_color(self)
-                plotting_tools.plot_figure(self, self.canvas, item.xdata, item.ydata, item.filename, item.color, y_axis, x_axis)
+                plotting_tools.plot_figure(self, self.canvas, item.xdata, item.ydata, item.filename, item.color, y_axis=y_axis, x_axis=x_axis)
                 add_sample_to_menu(self, item.filename, item.color, item.key, select_item=True)
     self.canvas.draw()
     plotting_tools.set_canvas_limits_axis(self, self.canvas)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -59,19 +59,15 @@ def open_files(self, files, import_settings):
                                 self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Item \'{item.filename}\' already exists'))
                                 return
                             elif handle_duplicates == 'Override existing items':
-                                y_axis = item.plot_y_position
-                                x_axis = item.plot_x_position
                                 self.datadict[key] = item
                                 plotting_tools.reload_plot(self)
                                 return
-                y_axis = item.plot_y_position
-                x_axis = item.plot_x_position
                 self.datadict[item.key] = item
                 item.color = plotting_tools.get_next_color(self)
-                plotting_tools.plot_figure(self, self.canvas, item.xdata, item.ydata, item.filename, item.color, y_axis=y_axis, x_axis=x_axis)
-                add_sample_to_menu(self, item.filename, item.color, item.key, select_item=True)
+                plotting_tools.plot_figure(self, self.canvas, item.xdata, item.ydata, filename=item.filename)
+                add_sample_to_menu(self, item.filename, item.color, item.key, select=True)
     self.canvas.draw()
-    plotting_tools.set_canvas_limits_axis(self, self.canvas)
+    plotting_tools.set_canvas_limits_axis(self)
     plotting_tools.refresh_plot(self)
     ui.enable_data_dependent_buttons(self, True)
 
@@ -105,12 +101,12 @@ def delete(self, key, give_toast=False):
     ui.enable_data_dependent_buttons(self, utilities.get_selected_keys(self))
 
 
-def add_sample_to_menu(self, filename, color, key, select_item=False):
+def add_sample_to_menu(self, filename, color, key, select=False):
     win = self.main_window
     win.list_box.set_visible(True)
     win.no_data_label_box.set_visible(False)
     self.list_box = win.list_box
-    row = samplerow.SampleBox(self, key, color, filename, select_item)
+    row = samplerow.SampleBox(self, key, color, filename, select)
     self.item_rows[key] = row
     self.list_box.append(row)
     self.sample_menu[key] = self.list_box.get_last_child()
@@ -128,7 +124,7 @@ def create_data_from_project(self, new_dictionary):
     revert to the default value.
     """
     self.datadict = {}
-    for key, item in new_dictionary.items():
+    for _key, item in new_dictionary.items():
         xdata = item.xdata
         ydata = item.ydata
         self.datadict[item.key] = Data(self, xdata, ydata)
@@ -153,9 +149,7 @@ def set_attributes(new_object, template):
 
 def load_empty(self):
     win = self.main_window
-    xlabel = self.plot_settings.xlabel
-    ylabel = self.plot_settings.ylabel
-    self.canvas = Canvas(parent=self, xlabel=xlabel, ylabel=ylabel)
+    self.canvas = Canvas(parent=self)
     for axis in [self.canvas.right_axis, self.canvas.top_left_axis, self.canvas.top_right_axis]:
         axis.get_xaxis().set_visible(False)
         axis.get_yaxis().set_visible(False)
@@ -164,7 +158,7 @@ def load_empty(self):
 
 
 def reset_clipboard(self):
-    for key, item in self.datadict.items():
+    for _key, item in self.datadict.items():
         item.xdata_clipboard = [item.xdata]
         item.ydata_clipboard = [item.ydata]
         item.clipboard_pos = -1

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -35,30 +35,30 @@ def open_files(self, files, import_settings):
         import_settings.mode = ImportMode.SINGLE
     for file in files:
         path = file.peek_path()
-        if path != "":
+        if path != '':
             try:
                 import_settings.path = path
                 item = file_io.get_data(self, import_settings)
                 if item.xdata == []:
-                    self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"At least one data set could not be imported"))
+                    self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'At least one data set could not be imported'))
                     continue
             except IndexError:
-                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"Could not open data, the column index was out of range"))
+                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Could not open data, the column index was out of range'))
                 break
             except UnicodeDecodeError:
-                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"Could not open data, wrong filetype"))
+                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Could not open data, wrong filetype'))
                 break
             if item is not None:
-                handle_duplicates = self.preferences.config["handle_duplicates"]
-                if not handle_duplicates == "Add duplicates":
+                handle_duplicates = self.preferences.config['handle_duplicates']
+                if not handle_duplicates == 'Add duplicates':
                     for key, item2 in self.datadict.items():
                         if item.filename == item2.filename:
-                            if handle_duplicates == "Auto-rename duplicates":
+                            if handle_duplicates == 'Auto-rename duplicates':
                                 item.filename = utilities.get_duplicate_filename(self, item.filename)
-                            elif handle_duplicates == "Ignore duplicates":
-                                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"Item \"{item.filename}\" already exists"))
+                            elif handle_duplicates == 'Ignore duplicates':
+                                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Item \'{item.filename}\' already exists'))
                                 return
-                            elif handle_duplicates == "Override existing items":
+                            elif handle_duplicates == 'Override existing items':
                                 y_axis = item.plot_Y_position
                                 x_axis = item.plot_X_position
                                 self.datadict[key] = item
@@ -90,7 +90,7 @@ def delete(self, id, give_toast = False):
     del self.item_rows[id]
     del self.datadict[id]
     if give_toast:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"Deleted {filename}"))
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Deleted {filename}'))
 
     if len(self.datadict) == 0:
         self.canvas.ax.legend().remove()

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -35,30 +35,30 @@ def open_files(self, files, import_settings):
         import_settings.mode = ImportMode.SINGLE
     for file in files:
         path = file.peek_path()
-        if path != '':
+        if path != "":
             try:
                 import_settings.path = path
                 item = file_io.get_data(self, import_settings)
                 if item.xdata == []:
-                    self.main_window.toast_overlay.add_toast(Adw.Toast(title='At least one data set could not be imported'))
+                    self.main_window.toast_overlay.add_toast(Adw.Toast(title="At least one data set could not be imported"))
                     continue
             except IndexError:
-                self.main_window.toast_overlay.add_toast(Adw.Toast(title='Could not open data, the column index was out of range'))
+                self.main_window.toast_overlay.add_toast(Adw.Toast(title="Could not open data, the column index was out of range"))
                 break
             except UnicodeDecodeError:
-                self.main_window.toast_overlay.add_toast(Adw.Toast(title='Could not open data, wrong filetype'))
+                self.main_window.toast_overlay.add_toast(Adw.Toast(title="Could not open data, wrong filetype"))
                 break
             if item is not None:
-                handle_duplicates = self.preferences.config['handle_duplicates']
-                if not handle_duplicates == 'Add duplicates':
+                handle_duplicates = self.preferences.config["handle_duplicates"]
+                if not handle_duplicates == "Add duplicates":
                     for key, item2 in self.datadict.items():
                         if item.filename == item2.filename:
-                            if handle_duplicates == 'Auto-rename duplicates':
+                            if handle_duplicates == "Auto-rename duplicates":
                                 item.filename = utilities.get_duplicate_filename(self, item.filename)
-                            elif handle_duplicates == 'Ignore duplicates':
-                                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Item \'{item.filename}\' already exists'))
+                            elif handle_duplicates == "Ignore duplicates":
+                                self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Item "{item.filename}" already exists'))
                                 return
-                            elif handle_duplicates == 'Override existing items':
+                            elif handle_duplicates == "Override existing items":
                                 self.datadict[key] = item
                                 plotting_tools.reload_plot(self)
                                 return
@@ -88,7 +88,7 @@ def delete(self, key, give_toast=False):
     del self.item_rows[key]
     del self.datadict[key]
     if give_toast:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Deleted {filename}'))
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"Deleted {filename}"))
 
     if len(self.datadict) == 0:
         self.canvas.ax.legend().remove()
@@ -136,7 +136,7 @@ def create_data_from_project(self, new_dictionary):
 def set_attributes(new_object, template):
     """
     Sets the attributes of `new_object` to match those of `template`.
-    This function sets the attributes of `new_object` to the values of the attributes in `template` if they don't already exist in `new_object`.
+    This function sets the attributes of `new_object` to the values of the attributes in `template` if they don"t already exist in `new_object`.
     Additionally, it removes any attributes from `new_object` that are not present in `template`.
     """
     for attribute in template.__dict__:

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -19,8 +19,8 @@ def add_to_clipboard(self):
     undo_button.set_sensitive(True)
 
     # If a couple of redo"s were performed previously, it deletes the clipboard
-    # data that is located after the current clipboard position and disables the
-    # redo button
+    # data that is located after the current clipboard position and disables
+    # the redo button
     for _key, item in self.datadict.items():
         delete_lists = - item.clipboard_pos - 1
         for _index in range(delete_lists):
@@ -55,8 +55,8 @@ def undo(self):
 
 def redo(self):
     """
-    Redo an action, moves the clipboard position forwards by one and changes the
-    dataset to the state before the previous action was undone
+    Redo an action, moves the clipboard position forwards by one and changes
+    the dataset to the state before the previous action was undone
     """
     undo_button = self.main_window.undo_button
     redo_button = self.main_window.redo_button
@@ -104,7 +104,8 @@ def pick_data_selection(self, item, startx, stopx):
         if value > stopx and not found_stop:
             stop_index = index
             found_stop = True
-    selected_data = Data(self, xdata[start_index:stop_index], ydata[start_index:stop_index])
+    selected_data = Data(self, xdata[start_index:stop_index],
+                         ydata[start_index:stop_index])
     if len(selected_data.xdata) > 0 and (found_start or found_stop):
         return selected_data, start_index, stop_index
     return None
@@ -137,9 +138,11 @@ def cut_data(self):
                     selected_item = self.datadict[f"{key}_selected"]
                     if selected_item is None:
                         continue
-                    for _index, (valuex, valuey) in enumerate(zip(xdata, ydata)):
+                    for _index, (valuex, valuey) \
+                            in enumerate(zip(xdata, ydata)):
                         # Appends the values that are within the selected span
-                        if valuex < min(selected_item.xdata) or valuex > max(selected_item.xdata):
+                        if valuex < min(selected_item.xdata) \
+                                or valuex > max(selected_item.xdata):
                             new_x.append(valuex)
                             new_y.append(valuey)
                     item.xdata = new_x
@@ -168,35 +171,63 @@ def select_data(self):
         start_index = 0
         stop_index = 0
 
-        # Selection is different for bottom and top axis. The span selector takes
-        # the top axis coordinates. So for the data that uses the bottom axis as
-        # x-axis coordinates, the coordinates first needs to be converted.
+        # Selection is different for bottom and top axis. The span selector
+        # takes the top axis coordinates. So for the data that uses the bottom
+        # axis as x-axis coordinates, the coordinates first
+        # needs to be converted.
         if item.plot_X_position == "bottom":
-            xrange_bottom = max(self.canvas.ax.get_xlim()) - min(self.canvas.ax.get_xlim())
-            xrange_top = max(self.canvas.top_left_axis.get_xlim()) - min(self.canvas.top_left_axis.get_xlim())
-            # Run into issues if the range is different, so we calculate this by
-            # getting what fraction of top axis is highlighted
+            xrange_bottom = max(self.canvas.ax.get_xlim()) \
+                - min(self.canvas.ax.get_xlim())
+            xrange_top = max(self.canvas.top_left_axis.get_xlim()) \
+                - min(self.canvas.top_left_axis.get_xlim())
+            # Run into issues if the range is different, so we calculate this
+            # by getting what fraction of top axis is highlighted
             if self.canvas.top_left_axis.get_xscale() == "log":
-                fraction_left_limit = get_fraction_at_value(min(highlight.extents), min(self.canvas.top_left_axis.get_xlim()), max(self.canvas.top_left_axis.get_xlim()))
-                fraction_right_limit = get_fraction_at_value(max(highlight.extents), min(self.canvas.top_left_axis.get_xlim()), max(self.canvas.top_left_axis.get_xlim()))
+                fraction_left_limit = get_fraction_at_value(
+                    min(highlight.extents),
+                    min(self.canvas.top_left_axis.get_xlim()),
+                    max(self.canvas.top_left_axis.get_xlim()))
+                fraction_right_limit = get_fraction_at_value(
+                    max(highlight.extents),
+                    min(self.canvas.top_left_axis.get_xlim()),
+                    max(self.canvas.top_left_axis.get_xlim()))
             elif self.canvas.top_left_axis.get_xscale() == "linear":
-                fraction_left_limit = (min(highlight.extents) - min(self.canvas.top_left_axis.get_xlim())) / (xrange_top)
-                fraction_right_limit = (max(highlight.extents) - min(self.canvas.top_left_axis.get_xlim())) / (xrange_top)
+                fraction_left_limit = (
+                    min(highlight.extents) - min(
+                        self.canvas.top_left_axis.get_xlim())) / (xrange_top)
+                fraction_right_limit = (
+                    max(highlight.extents) - min(
+                        self.canvas.top_left_axis.get_xlim())) / (xrange_top)
 
             # Use the fraction that is higlighted on top to calculate to what
             # values this corresponds on bottom axis
             if self.canvas.ax.get_xscale() == "log":
-                startx = get_value_at_fraction(fraction_left_limit, min(self.canvas.ax.get_xlim()), max(self.canvas.ax.get_xlim()))
-                stopx = get_value_at_fraction(fraction_right_limit, min(self.canvas.ax.get_xlim()), max(self.canvas.ax.get_xlim()))
+                startx = get_value_at_fraction(
+                    fraction_left_limit,
+                    min(self.canvas.ax.get_xlim()),
+                    max(self.canvas.ax.get_xlim()))
+                stopx = get_value_at_fraction(
+                    fraction_right_limit,
+                    min(self.canvas.ax.get_xlim()),
+                    max(self.canvas.ax.get_xlim()))
             elif self.canvas.ax.get_xscale() == "linear":
-                startx = min(self.canvas.ax.get_xlim()) + xrange_bottom * fraction_left_limit
-                stopx = min(self.canvas.ax.get_xlim()) + xrange_bottom * fraction_right_limit
+                startx = min(
+                    self.canvas.ax.get_xlim())
+                + xrange_bottom * fraction_left_limit
+                stopx = min(
+                    self.canvas.ax.get_xlim())
+                + xrange_bottom * fraction_right_limit
 
-        # If startx and stopx are not out of range, that is, if the sample data is within the highlight
-        if not ((startx < min(item.xdata) and stopx < min(item.xdata)) or (startx > max(item.xdata))):
-            selected_data, start_index, stop_index = pick_data_selection(self, item, startx, stopx)
+        # If startx and stopx are not out of range, that is,
+        # if the sample data is within the highlight
+        if not ((startx < min(
+                item.xdata) and stopx < min(
+                    item.xdata)) or (startx > max(item.xdata))):
+            selected_data, start_index, stop_index = pick_data_selection(
+                self, item, startx, stopx)
             selected_dict[f"{key}_selected"] = selected_data
-        if (startx < min(item.xdata) and stopx < min(item.xdata)) or (startx > max(item.xdata)):
+        if (startx < min(item.xdata) and stopx < min(item.xdata)) \
+                or (startx > max(item.xdata)):
             delete_selected_data(self)
         # Update the dataset to include the selected data, only if we actually
         # managed to select data.
@@ -339,7 +370,8 @@ def combine_data(self):
     filename_list = utilities.get_all_filenames(self)
 
     if new_item.filename in filename_list:
-        new_item.filename = graphs.get_duplicate_filename(self, new_item.filename)
+        new_item.filename = graphs.get_duplicate_filename(
+            self, new_item.filename)
     color = plotting_tools.get_next_color(self)
     self.datadict[new_item.key] = new_item
     delete_selected_data(self)
@@ -362,7 +394,8 @@ def smoothen_data(self):
             selected_item.ydata = smooth(selected_item.ydata, 4)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
-            self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
+            self.datadict[key].ydata[
+                start_index:stop_index] = selected_item.ydata
         if self.interaction_mode != InteractionMode.SELECT:
             ydata = self.datadict[key].ydata
             ydata = smooth(ydata, 4)
@@ -402,9 +435,11 @@ def shift_vertically(self):
             ymax = max(x for x in selected_item.ydata if x != 0)
             shift_value_linear += 1.2 * (ymax - ymin)
             shift_value_log *= 10 ** (np.log10(ymax / ymin))
-            shift_item(self, selected_item, shift_value_log, shift_value_linear)
+            shift_item(
+                self, selected_item, shift_value_log, shift_value_linear)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
-            self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
+            self.datadict[key].ydata[
+                start_index:stop_index] = selected_item.ydata
         if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
             ymin = min(x for x in item.ydata if x != 0)
@@ -445,8 +480,9 @@ def translate_x(self):
         offset = eval(win.translate_x_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f"{exception}: Unable to do translation, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do translation, make sure to enter a valid number"))
+        toast = f"{exception_type}: Unable to do translation, "
+        + "make sure to enter a valid number"
+        win.toast_overlay.add_toast(Adw.Toast(title=toast))
         offset = 0
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
@@ -456,13 +492,17 @@ def translate_x(self):
             # Define the highlighted area
             selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
-            selected_item.xdata = [value + offset for value in selected_item.xdata]
+            selected_item.xdata = [
+                value + offset for value in selected_item.xdata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
-            self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
+            self.datadict[key].xdata[
+                start_index:stop_index] = selected_item.xdata
         if self.interaction_mode != InteractionMode.SELECT:
-            self.datadict[key].xdata = [value + offset for value in self.datadict[key].xdata]
-        self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
+            self.datadict[key].xdata = [
+                value + offset for value in self.datadict[key].xdata]
+        self.datadict[key].xdata, self.datadict[key].ydata = sort_data(
+            self.datadict[key].xdata, self.datadict[key].ydata)
     add_to_clipboard(self)
     delete_selected_data(self)
     plotting_tools.refresh_plot(self)
@@ -480,8 +520,9 @@ def translate_y(self):
         offset = eval(win.translate_y_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f"{exception}: Unable to do translation, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do translation, make sure to enter a valid number"))
+        toast = f"{exception_type}: Unable to do translation, "
+        + "make sure to enter a valid number"
+        win.toast_overlay.add_toast(Adw.Toast(title=toast))
         offset = 0
     selected_keys = utilities.get_selected_keys(self)
 
@@ -489,18 +530,22 @@ def translate_y(self):
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        # If the selected data exists, so this will get ignored when we"re
+        # not in selection mode
         if f"{key}_selected" in self.datadict:
             print(self.datadict[key].filename)
             # Define the highlighted area
             selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
-            selected_item.ydata = [value + offset for value in selected_item.ydata]
+            selected_item.ydata = [
+                value + offset for value in selected_item.ydata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
-            self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
+            self.datadict[key].ydata[
+                start_index:stop_index] = selected_item.ydata
         if self.interaction_mode != InteractionMode.SELECT:
-            self.datadict[key].ydata = [value + offset for value in self.datadict[key].ydata]
+            self.datadict[key].ydata = [
+                value + offset for value in self.datadict[key].ydata]
     add_to_clipboard(self)
     # Throw away the selected/highlighted datasets
     delete_selected_data(self)
@@ -519,25 +564,31 @@ def multiply_x(self):
         multiplier = eval(win.multiply_x_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f"{exception}: Unable to do multiplication, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do multiplication, make sure to enter a valid number"))
+        toast = f"{exception_type}: Unable to do multiplication, "
+        + "make sure to enter a valid number"
+        win.toast_overlay.add_toast(Adw.Toast(title=toast))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        # If the selected data exists, so this will get ignored when
+        # we"re not in selection mode
         if f"{key}_selected" in self.datadict:
             # Define the highlighted area
             selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
-            selected_item.xdata = [value * multiplier for value in selected_item.xdata]
+            selected_item.xdata = [
+                value * multiplier for value in selected_item.xdata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
-            self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
+            self.datadict[key].xdata[
+                start_index:stop_index] = selected_item.xdata
         if self.interaction_mode != InteractionMode.SELECT:
-            self.datadict[key].xdata = [value * multiplier for value in self.datadict[key].xdata]
-        self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
+            self.datadict[key].xdata = [
+                value * multiplier for value in self.datadict[key].xdata]
+        self.datadict[key].xdata, self.datadict[key].ydata = sort_data(
+            self.datadict[key].xdata, self.datadict[key].ydata)
     delete_selected_data(self)
     add_to_clipboard(self)
     plotting_tools.refresh_plot(self)
@@ -555,24 +606,29 @@ def multiply_y(self):
         multiplier = eval(win.multiply_y_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f"{exception}: Unable to do multiplication, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do multiplication, make sure to enter a valid number"))
+        toast = f"{exception_type}: Unable to do multiplication, "
+        + "make sure to enter a valid number"
+        win.toast_overlay.add_toast(Adw.Toast(title=toast))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        # If the selected data exists, so this will get ignored when
+        # we"re not in selection mode
         if f"{key}_selected" in self.datadict:
             # Define the highlighted area
             selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
-            selected_item.ydata = [value * multiplier for value in selected_item.ydata]
+            selected_item.ydata = [
+                value * multiplier for value in selected_item.ydata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
-            self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
+            self.datadict[key].ydata[
+                start_index:stop_index] = selected_item.ydata
         if self.interaction_mode != InteractionMode.SELECT:
-            self.datadict[key].ydata = [value * multiplier for value in self.datadict[key].ydata]
+            self.datadict[key].ydata = [
+                value * multiplier for value in self.datadict[key].ydata]
     delete_selected_data(self)
     add_to_clipboard(self)
     plotting_tools.refresh_plot(self)
@@ -584,7 +640,8 @@ def normalize_data(self):
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        # If the selected data exists, so this will get ignored when we"re
+        # not in selection mode
         if f"{key}_selected" in self.datadict:
             # Define the highlighted area
             selected_item = self.datadict[f"{key}_selected"]
@@ -592,8 +649,10 @@ def normalize_data(self):
             selected_item.ydata = normalize(selected_item.ydata)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
-            self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
-            self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
+            self.datadict[key].ydata[
+                start_index:stop_index] = selected_item.ydata
+            self.datadict[key].xdata[
+                start_index:stop_index] = selected_item.xdata
         if self.interaction_mode != InteractionMode.SELECT:
             self.datadict[key].ydata = normalize(self.datadict[key].ydata)
     delete_selected_data(self)
@@ -621,26 +680,38 @@ def center_data(self):
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        # If the selected data exists, so this will get ignored when we"re
+        # not in selection mode
         if f"{key}_selected" in self.datadict:
             # Define the highlighted area
             selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
-            if self.preferences.config["action_center_data"] == "Center at maximum Y value":
-                selected_item.xdata = center_data_max_y(selected_item.xdata, selected_item.ydata)
-            elif self.preferences.config["action_center_data"] == "Center at middle coordinate":
+            if self.preferences.config[
+                    "action_center_data"] == "Center at maximum Y value":
+                selected_item.xdata = center_data_max_y(
+                    selected_item.xdata, selected_item.ydata)
+            elif self.preferences.config[
+                    "action_center_data"] == "Center at middle coordinate":
                 selected_item.xdata = center_data_middle(selected_item.xdata)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
-            self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
-            self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
-            self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
+            self.datadict[key].ydata[
+                start_index:stop_index] = selected_item.ydata
+            self.datadict[key].xdata[
+                start_index:stop_index] = selected_item.xdata
+            self.datadict[key].xdata, self.datadict[key].ydata = sort_data(
+                self.datadict[key].xdata, self.datadict[key].ydata)
         if self.interaction_mode != InteractionMode.SELECT:
-            if self.preferences.config["action_center_data"] == "Center at maximum Y value":
-                self.datadict[key].xdata = center_data_max_y(self.datadict[key].xdata, self.datadict[key].ydata)
-            elif self.preferences.config["action_center_data"] == "Center at middle coordinate":
-                self.datadict[key].xdata = center_data_middle(self.datadict[key].xdata)
-            self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
+            if self.preferences.config[
+                    "action_center_data"] == "Center at maximum Y value":
+                self.datadict[key].xdata = center_data_max_y(
+                    self.datadict[key].xdata, self.datadict[key].ydata)
+            elif self.preferences.config[
+                    "action_center_data"] == "Center at middle coordinate":
+                self.datadict[key].xdata = center_data_middle(
+                    self.datadict[key].xdata)
+            self.datadict[key].xdata, self.datadict[key].ydata = sort_data(
+                self.datadict[key].xdata, self.datadict[key].ydata)
     delete_selected_data(self)
     add_to_clipboard(self)
     plotting_tools.refresh_plot(self)

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -21,9 +21,9 @@ def add_to_clipboard(self):
     # If a couple of redo's were performed previously, it deletes the clipboard
     # data that is located after the current clipboard position and disables the
     # redo button
-    for key, item in self.datadict.items():
+    for _key, item in self.datadict.items():
         delete_lists = - item.clipboard_pos - 1
-        for index in range(delete_lists):
+        for _index in range(delete_lists):
             del item.xdata_clipboard[-1]
             del item.ydata_clipboard[-1]
         if delete_lists != 0:
@@ -42,7 +42,7 @@ def undo(self):
     """
     undo_button = self.main_window.undo_button
     redo_button = self.main_window.redo_button
-    for key, item in self.datadict.items():
+    for _key, item in self.datadict.items():
         if abs(item.clipboard_pos) < len(item.xdata_clipboard):
             redo_button.set_sensitive(True)
             item.clipboard_pos -= 1
@@ -60,7 +60,7 @@ def redo(self):
     """
     undo_button = self.main_window.undo_button
     redo_button = self.main_window.redo_button
-    for key, item in self.datadict.items():
+    for _key, item in self.datadict.items():
         if item.clipboard_pos < 0:
             undo_button.set_sensitive(True)
             item.clipboard_pos += 1
@@ -107,6 +107,7 @@ def pick_data_selection(self, item, startx, stopx):
     selected_data = Data(self, xdata[start_index:stop_index], ydata[start_index:stop_index])
     if len(selected_data.xdata) > 0 and (found_start or found_stop):
         return selected_data, start_index, stop_index
+    return None
 
 
 def sort_data(x_values, y_values):
@@ -124,7 +125,7 @@ def cut_data(self):
     """
     Cut selected data over the span that is selected
     """
-    if self._mode == InteractionMode.SELECT:
+    if self.interaction_mode == InteractionMode.SELECT:
         if select_data(self):  # If select_data ran succesfully
             for key, item in self.datadict.items():
                 xdata = item.xdata
@@ -138,7 +139,7 @@ def cut_data(self):
                     selected_item = self.datadict[f'{key}_selected']
                     if selected_item is None:
                         continue
-                    for index, (valuex, valuey) in enumerate(zip(xdata, ydata)):
+                    for _index, (valuex, valuey) in enumerate(zip(xdata, ydata)):
                         # Appends the values that are within the selected span
                         if valuex < min(selected_item.xdata) or valuex > max(selected_item.xdata):
                             new_x.append(valuex)
@@ -236,13 +237,13 @@ def get_derivative(self):
     """
     Calculate derivative of all selected data
     """
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
             item = self.datadict[f'{key}_selected']
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
         y_values = np.array(item.ydata)
@@ -258,13 +259,13 @@ def get_integral(self):
     """
     Calculate indefinite integral of all selected data
     """
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
             item = self.datadict[f'{key}_selected']
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
         y_values = np.array(item.ydata)
@@ -281,13 +282,13 @@ def get_fourier(self):
     """
     Perform Fourier transformation on all selected data
     """
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
             item = self.datadict[f'{key}_selected']
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
         y_values = np.array(item.ydata)
@@ -305,13 +306,13 @@ def get_inverse_fourier(self):
     """
     Perform Inverse Fourier transformation on all selected data
     """
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
             item = self.datadict[f'{key}_selected']
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
         y_values = np.array(item.ydata)
@@ -329,8 +330,8 @@ def combine_data(self):
     """
     Combine the selected data into a new data set
     """
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        select_data(self)
     selected_keys = utilities.get_selected_keys(self)
 
     new_xdata = []
@@ -338,7 +339,7 @@ def combine_data(self):
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
             item = self.datadict[f'{key}_selected']
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         new_xdata.extend(item.xdata.copy())
         new_ydata.extend(item.ydata.copy())
@@ -365,8 +366,8 @@ def smoothen_data(self):
     Smoothen y-data.
     """
     selected_keys = utilities.get_selected_keys(self)
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
             # Define the highlighted area
@@ -376,7 +377,7 @@ def smoothen_data(self):
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
             self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             ydata = self.datadict[key].ydata
             ydata = smooth(ydata, 4)
             self.datadict[key].ydata = ydata
@@ -404,8 +405,8 @@ def shift_vertically(self):
     selected_keys = utilities.get_selected_keys(self)
     shift_value_log = 1
     shift_value_linear = 0
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
 
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
@@ -418,7 +419,7 @@ def shift_vertically(self):
             shift_item(self, selected_item, shift_value_log, shift_value_linear)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
             ymin = min(x for x in item.ydata if x != 0)
             ymax = max(x for x in item.ydata if x != 0)
@@ -461,8 +462,8 @@ def translate_x(self):
         print(f'{exception}: Unable to do translation, make sure to enter a valid number')
         win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do translation, make sure to enter a valid number'))
         offset = 0
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
@@ -473,7 +474,7 @@ def translate_x(self):
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
             self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             self.datadict[key].xdata = [value + offset for value in self.datadict[key].xdata]
         self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
     add_to_clipboard(self)
@@ -499,8 +500,8 @@ def translate_y(self):
     selected_keys = utilities.get_selected_keys(self)
 
     # If we are in selection mode, then select the highlighted data
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
     for key in selected_keys:
         # If the selected data exists, so this will get ignored when we're not in selection mode
         if f'{key}_selected' in self.datadict:
@@ -512,7 +513,7 @@ def translate_y(self):
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
             self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             self.datadict[key].ydata = [value + offset for value in self.datadict[key].ydata]
     add_to_clipboard(self)
     # Throw away the selected/highlighted datasets
@@ -536,8 +537,8 @@ def multiply_x(self):
         win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
     for key in selected_keys:
         # If the selected data exists, so this will get ignored when we're not in selection mode
         if f'{key}_selected' in self.datadict:
@@ -548,7 +549,7 @@ def multiply_x(self):
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
             self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             self.datadict[key].xdata = [value * multiplier for value in self.datadict[key].xdata]
         self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
     delete_selected_data(self)
@@ -572,8 +573,8 @@ def multiply_y(self):
         win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
     for key in selected_keys:
         # If the selected data exists, so this will get ignored when we're not in selection mode
         if f'{key}_selected' in self.datadict:
@@ -584,7 +585,7 @@ def multiply_y(self):
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
             self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             self.datadict[key].ydata = [value * multiplier for value in self.datadict[key].ydata]
     delete_selected_data(self)
     add_to_clipboard(self)
@@ -596,8 +597,8 @@ def normalize_data(self):
     Normalize all selected data
     """
     selected_keys = utilities.get_selected_keys(self)
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
     for key in selected_keys:
         # If the selected data exists, so this will get ignored when we're not in selection mode
         if f'{key}_selected' in self.datadict:
@@ -609,7 +610,7 @@ def normalize_data(self):
             # Replace the highlighted part in the original data set
             self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
             self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             self.datadict[key].ydata = normalize(self.datadict[key].ydata)
     delete_selected_data(self)
     add_to_clipboard(self)
@@ -633,8 +634,8 @@ def center_data(self):
     the maximum value of the data
     """
     selected_keys = utilities.get_selected_keys(self)
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = select_data(self)
     for key in selected_keys:
         # If the selected data exists, so this will get ignored when we're not in selection mode
         if f'{key}_selected' in self.datadict:
@@ -650,7 +651,7 @@ def center_data(self):
             self.datadict[key].ydata[start_index:stop_index] = selected_item.ydata
             self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
             self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             if self.preferences.config['action_center_data'] == 'Center at maximum Y value':
                 self.datadict[key].xdata = center_data_max_y(self.datadict[key].xdata, self.datadict[key].ydata)
             elif self.preferences.config['action_center_data'] == 'Center at middle coordinate':

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -76,7 +76,7 @@ def delete_selected_data(self):
     """
     key_list = []
     for key in self.datadict:
-        if key.endswith("_selected"):
+        if key.endswith('_selected'):
             key_list.append(key)
     for key in key_list:
         del (self.datadict[key])
@@ -130,8 +130,8 @@ def cut_data(self):
                 new_y = []
                 
                 #If our item is among the selected samples, we will cut those
-                if f"{key}_selected" in self.datadict:
-                    selected_item = self.datadict[f"{key}_selected"]
+                if f'{key}_selected' in self.datadict:
+                    selected_item = self.datadict[f'{key}_selected']
                     if selected_item is None:
                         continue
                     for index, (valuex, valuey) in enumerate(zip(xdata, ydata)):
@@ -148,7 +148,7 @@ def cut_data(self):
 def select_data(self):
     """
     Select data that is highlighted by the span
-    Basically just creates new data_sets with the key "_selected" appended
+    Basically just creates new data_sets with the key '_selected' appended
     """
     #First delete previously selected data
     delete_selected_data(self)
@@ -167,31 +167,31 @@ def select_data(self):
         #Selection is different for bottom and top axis. The span selector takes
         #the top axis coordinates. So for the data that uses the bottom axis as
         #x-axis coordinates, the coordinates first needs to be converted.
-        if item.plot_X_position == "bottom":
+        if item.plot_X_position == 'bottom':
             xrange_bottom = max(self.canvas.ax.get_xlim()) - min(self.canvas.ax.get_xlim())
             xrange_top = max(self.canvas.top_left_axis.get_xlim()) - min(self.canvas.top_left_axis.get_xlim())
             #Run into issues if the range is different, so we calculate this by
             #getting what fraction of top axis is highlighted
-            if self.canvas.top_left_axis.get_xscale() == "log":
+            if self.canvas.top_left_axis.get_xscale() == 'log':
                 fraction_left_limit = get_fraction_at_value(min(highlight.extents), min(self.canvas.top_left_axis.get_xlim()), max(self.canvas.top_left_axis.get_xlim()))
                 fraction_right_limit = get_fraction_at_value(max(highlight.extents), min(self.canvas.top_left_axis.get_xlim()), max(self.canvas.top_left_axis.get_xlim()))
-            elif self.canvas.top_left_axis.get_xscale() == "linear":
+            elif self.canvas.top_left_axis.get_xscale() == 'linear':
                 fraction_left_limit = (min(highlight.extents) - min(self.canvas.top_left_axis.get_xlim())) / (xrange_top)
                 fraction_right_limit = (max(highlight.extents) - min(self.canvas.top_left_axis.get_xlim())) / (xrange_top)
 
             #Use the fraction that is higlighted on top to calculate to what
             #values this corresponds on bottom axis
-            if self.canvas.ax.get_xscale() == "log":
+            if self.canvas.ax.get_xscale() == 'log':
                 startx = get_value_at_fraction(fraction_left_limit, min(self.canvas.ax.get_xlim()), max(self.canvas.ax.get_xlim()))
                 stopx = get_value_at_fraction(fraction_right_limit, min(self.canvas.ax.get_xlim()), max(self.canvas.ax.get_xlim()))
-            elif self.canvas.ax.get_xscale() == "linear":  
+            elif self.canvas.ax.get_xscale() == 'linear':  
                 startx = min(self.canvas.ax.get_xlim()) + xrange_bottom * fraction_left_limit
                 stopx = min(self.canvas.ax.get_xlim()) + xrange_bottom * fraction_right_limit
 
         #If startx and stopx are not out of range, that is, if the sample data is within the highlight
         if not ((startx < min(item.xdata) and stopx < min(item.xdata)) or (startx > max(item.xdata))):
             selected_data, start_index, stop_index = pick_data_selection(self, item, startx, stopx)
-            selected_dict[f"{key}_selected"] = selected_data
+            selected_dict[f'{key}_selected'] = selected_data
         if (startx < min(item.xdata) and stopx < min(item.xdata)) or (startx > max(item.xdata)):
             delete_selected_data(self)
         #Update the dataset to include the selected data, only if we actually
@@ -232,8 +232,8 @@ def get_derivative(self):
         selection, start_stop = select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
-            item = self.datadict[f"{key}_selected"]
+        if f'{key}_selected' in self.datadict:
+            item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x = np.array(item.xdata)
@@ -253,8 +253,8 @@ def get_integral(self):
         selection, start_stop = select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
-            item = self.datadict[f"{key}_selected"]
+        if f'{key}_selected' in self.datadict:
+            item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x = np.array(item.xdata)
@@ -275,8 +275,8 @@ def get_fourier(self):
         selection, start_stop = select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
-            item = self.datadict[f"{key}_selected"]
+        if f'{key}_selected' in self.datadict:
+            item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x = np.array(item.xdata)
@@ -298,8 +298,8 @@ def get_inverse_fourier(self):
         selection, start_stop = select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
-            item = self.datadict[f"{key}_selected"]
+        if f'{key}_selected' in self.datadict:
+            item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x = np.array(item.xdata)
@@ -325,8 +325,8 @@ def combine_data(self):
     new_xdata = []
     new_ydata = []
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
-            item = self.datadict[f"{key}_selected"]
+        if f'{key}_selected' in self.datadict:
+            item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
         new_xdata.extend(item.xdata.copy())
@@ -336,7 +336,7 @@ def combine_data(self):
     #Create the sample itself
     new_xdata, new_ydata = sort_data(new_xdata, new_ydata)
     new_item = Data(self, new_xdata, new_ydata)
-    new_item.filename = "Combined Data"
+    new_item.filename = 'Combined Data'
     filename_list = utilities.get_all_filenames(self)
         
     if new_item.filename in filename_list:
@@ -358,9 +358,9 @@ def smoothen_data(self):
     if self._mode == InteractionMode.SELECT:
         selection, start_stop = select_data(self)
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             #Perform the operation on the highlighted area
             selected_item.ydata = smooth(selected_item.ydata, 4)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -380,7 +380,7 @@ def smooth(y_data, box_points):
     values are used for smoothening. Returns smoothened array
     """
     box = np.ones(box_points) / box_points
-    y_smooth = np.convolve(y_data, box, mode="same")
+    y_smooth = np.convolve(y_data, box, mode='same')
     return y_smooth
 
 def shift_vertically(self):
@@ -396,9 +396,9 @@ def shift_vertically(self):
         selection, start_stop = select_data(self)
         
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             ymin = min(x for x in selected_item.ydata if x != 0)
             ymax = max(x for x in selected_item.ydata if x != 0)
             shift_value_linear += 1.2*(ymax - ymin)
@@ -421,15 +421,15 @@ def shift_vertically(self):
 def shift_item(self, item, shift_value_log, shift_value_linear):
     #Check which axes the data is on, so it can choose the appropriate
     #scaling (log/linear)
-    if item.plot_Y_position == "left":
-        if self.plot_settings.yscale == "log":
+    if item.plot_Y_position == 'left':
+        if self.plot_settings.yscale == 'log':
             item.ydata = [value * shift_value_log for value in item.ydata]
-        if self.plot_settings.yscale == "linear":
+        if self.plot_settings.yscale == 'linear':
             item.ydata = [value + shift_value_linear for value in item.ydata]
-    if item.plot_Y_position == "right":
-        if self.plot_settings.right_scale == "log":
+    if item.plot_Y_position == 'right':
+        if self.plot_settings.right_scale == 'log':
             item.ydata = [value * shift_value_log for value in item.ydata]
-        if self.plot_settings.right_scale == "linear":
+        if self.plot_settings.right_scale == 'linear':
             item.ydata = [value + shift_value_linear for value in item.ydata]
 
 def translate_x(self):
@@ -444,16 +444,16 @@ def translate_x(self):
         offset = eval(win.translate_x_entry.get_text())
     except Exception as e:
         exception_type = e.__class__.__name__
-        print(f"{e}: Unable to do translation, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do translation, make sure to enter a valid number"))
+        print(f'{e}: Unable to do translation, make sure to enter a valid number')
+        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do translation, make sure to enter a valid number'))
         offset = 0
     if self._mode == InteractionMode.SELECT:
         selection, start_stop = select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             #Perform the operation on the highlighted area
             selected_item.xdata = [value + offset for value in selected_item.xdata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -478,8 +478,8 @@ def translate_y(self):
         offset = eval(win.translate_y_entry.get_text())
     except Exception as e:
         exception_type = e.__class__.__name__
-        print(f"{e}: Unable to do translation, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do translation, make sure to enter a valid number"))
+        print(f'{e}: Unable to do translation, make sure to enter a valid number')
+        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do translation, make sure to enter a valid number'))
         offset = 0
     selected_keys = utilities.get_selected_keys(self)
 
@@ -488,10 +488,10 @@ def translate_y(self):
         selection, start_stop = select_data(self)
     for key in selected_keys:
         #If the selected data exists, so this will get ignored when we're not in selection mode
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             print(self.datadict[key].filename)
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             #Perform the operation on the highlighted area
             selected_item.ydata = [value + offset for value in selected_item.ydata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -516,17 +516,17 @@ def multiply_x(self):
         multiplier = eval(win.multiply_x_entry.get_text())
     except Exception as e:
         exception_type = e.__class__.__name__
-        print(f"{e}: Unable to do multiplication, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do multiplication, make sure to enter a valid number"))
+        print(f'{e}: Unable to do multiplication, make sure to enter a valid number')
+        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
     if self._mode == InteractionMode.SELECT:
         selection, start_stop = select_data(self)
     for key in selected_keys:
         #If the selected data exists, so this will get ignored when we're not in selection mode
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             #Perform the operation on the highlighted area
             selected_item.xdata = [value * multiplier for value in selected_item.xdata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -551,17 +551,17 @@ def multiply_y(self):
         multiplier = eval(win.multiply_y_entry.get_text())
     except Exception as e:
         exception_type = e.__class__.__name__
-        print(f"{e}: Unable to do multiplication, make sure to enter a valid number")
-        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do multiplication, make sure to enter a valid number"))
+        print(f'{e}: Unable to do multiplication, make sure to enter a valid number')
+        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
     if self._mode == InteractionMode.SELECT:
         selection, start_stop = select_data(self)
     for key in selected_keys:
         #If the selected data exists, so this will get ignored when we're not in selection mode
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             #Perform the operation on the highlighted area
             selected_item.ydata = [value * multiplier for value in selected_item.ydata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -583,9 +583,9 @@ def normalize_data(self):
         selection, start_stop = select_data(self)
     for key in selected_keys:
         #If the selected data exists, so this will get ignored when we're not in selection mode
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             #Perform the operation on the highlighted area
             selected_item.ydata = normalize(selected_item.ydata)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -618,13 +618,13 @@ def center_data(self):
         selection, start_stop = select_data(self)
     for key in selected_keys:
         #If the selected data exists, so this will get ignored when we're not in selection mode
-        if f"{key}_selected" in self.datadict:
+        if f'{key}_selected' in self.datadict:
             #Define the highlighted area
-            selected_item = self.datadict[f"{key}_selected"]
+            selected_item = self.datadict[f'{key}_selected']
             #Perform the operation on the highlighted area
-            if self.preferences.config["action_center_data"] == "Center at maximum Y value":
+            if self.preferences.config['action_center_data'] == 'Center at maximum Y value':
                 selected_item.xdata = center_data_max_Y(selected_item.xdata, selected_item.ydata)
-            elif self.preferences.config["action_center_data"] == "Center at middle coordinate":
+            elif self.preferences.config['action_center_data'] == 'Center at middle coordinate':
                 selected_item.xdata = center_data_middle(selected_item.xdata)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             #Replace the highlighted part in the original data set
@@ -632,9 +632,9 @@ def center_data(self):
             self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
             self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
         if self._mode != InteractionMode.SELECT:
-            if self.preferences.config["action_center_data"] == "Center at maximum Y value":
+            if self.preferences.config['action_center_data'] == 'Center at maximum Y value':
                 self.datadict[key].xdata = center_data_max_Y(self.datadict[key].xdata, self.datadict[key].ydata)
-            elif self.preferences.config["action_center_data"] == "Center at middle coordinate":
+            elif self.preferences.config['action_center_data'] == 'Center at middle coordinate':
                 self.datadict[key].xdata = center_data_middle(self.datadict[key].xdata)
             self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
     delete_selected_data(self)

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -18,7 +18,7 @@ def add_to_clipboard(self):
     undo_button = self.main_window.undo_button
     undo_button.set_sensitive(True)
 
-    # If a couple of redo's were performed previously, it deletes the clipboard
+    # If a couple of redo"s were performed previously, it deletes the clipboard
     # data that is located after the current clipboard position and disables the
     # redo button
     for _key, item in self.datadict.items():
@@ -79,7 +79,7 @@ def delete_selected_data(self):
     """
     key_list = []
     for key in self.datadict:
-        if key.endswith('_selected'):
+        if key.endswith("_selected"):
             key_list.append(key)
     for key in key_list:
         del (self.datadict[key])
@@ -133,8 +133,8 @@ def cut_data(self):
                 new_y = []
 
                 # If our item is among the selected samples, we will cut those
-                if f'{key}_selected' in self.datadict:
-                    selected_item = self.datadict[f'{key}_selected']
+                if f"{key}_selected" in self.datadict:
+                    selected_item = self.datadict[f"{key}_selected"]
                     if selected_item is None:
                         continue
                     for _index, (valuex, valuey) in enumerate(zip(xdata, ydata)):
@@ -152,7 +152,7 @@ def cut_data(self):
 def select_data(self):
     """
     Select data that is highlighted by the span
-    Basically just creates new data_sets with the key '_selected' appended
+    Basically just creates new data_sets with the key "_selected" appended
     """
     # First delete previously selected data
     delete_selected_data(self)
@@ -171,31 +171,31 @@ def select_data(self):
         # Selection is different for bottom and top axis. The span selector takes
         # the top axis coordinates. So for the data that uses the bottom axis as
         # x-axis coordinates, the coordinates first needs to be converted.
-        if item.plot_X_position == 'bottom':
+        if item.plot_X_position == "bottom":
             xrange_bottom = max(self.canvas.ax.get_xlim()) - min(self.canvas.ax.get_xlim())
             xrange_top = max(self.canvas.top_left_axis.get_xlim()) - min(self.canvas.top_left_axis.get_xlim())
             # Run into issues if the range is different, so we calculate this by
             # getting what fraction of top axis is highlighted
-            if self.canvas.top_left_axis.get_xscale() == 'log':
+            if self.canvas.top_left_axis.get_xscale() == "log":
                 fraction_left_limit = get_fraction_at_value(min(highlight.extents), min(self.canvas.top_left_axis.get_xlim()), max(self.canvas.top_left_axis.get_xlim()))
                 fraction_right_limit = get_fraction_at_value(max(highlight.extents), min(self.canvas.top_left_axis.get_xlim()), max(self.canvas.top_left_axis.get_xlim()))
-            elif self.canvas.top_left_axis.get_xscale() == 'linear':
+            elif self.canvas.top_left_axis.get_xscale() == "linear":
                 fraction_left_limit = (min(highlight.extents) - min(self.canvas.top_left_axis.get_xlim())) / (xrange_top)
                 fraction_right_limit = (max(highlight.extents) - min(self.canvas.top_left_axis.get_xlim())) / (xrange_top)
 
             # Use the fraction that is higlighted on top to calculate to what
             # values this corresponds on bottom axis
-            if self.canvas.ax.get_xscale() == 'log':
+            if self.canvas.ax.get_xscale() == "log":
                 startx = get_value_at_fraction(fraction_left_limit, min(self.canvas.ax.get_xlim()), max(self.canvas.ax.get_xlim()))
                 stopx = get_value_at_fraction(fraction_right_limit, min(self.canvas.ax.get_xlim()), max(self.canvas.ax.get_xlim()))
-            elif self.canvas.ax.get_xscale() == 'linear':
+            elif self.canvas.ax.get_xscale() == "linear":
                 startx = min(self.canvas.ax.get_xlim()) + xrange_bottom * fraction_left_limit
                 stopx = min(self.canvas.ax.get_xlim()) + xrange_bottom * fraction_right_limit
 
         # If startx and stopx are not out of range, that is, if the sample data is within the highlight
         if not ((startx < min(item.xdata) and stopx < min(item.xdata)) or (startx > max(item.xdata))):
             selected_data, start_index, stop_index = pick_data_selection(self, item, startx, stopx)
-            selected_dict[f'{key}_selected'] = selected_data
+            selected_dict[f"{key}_selected"] = selected_data
         if (startx < min(item.xdata) and stopx < min(item.xdata)) or (startx > max(item.xdata)):
             delete_selected_data(self)
         # Update the dataset to include the selected data, only if we actually
@@ -237,8 +237,8 @@ def get_derivative(self):
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
-            item = self.datadict[f'{key}_selected']
+        if f"{key}_selected" in self.datadict:
+            item = self.datadict[f"{key}_selected"]
         if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
@@ -257,8 +257,8 @@ def get_integral(self):
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
-            item = self.datadict[f'{key}_selected']
+        if f"{key}_selected" in self.datadict:
+            item = self.datadict[f"{key}_selected"]
         if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
@@ -278,8 +278,8 @@ def get_fourier(self):
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
-            item = self.datadict[f'{key}_selected']
+        if f"{key}_selected" in self.datadict:
+            item = self.datadict[f"{key}_selected"]
         if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
@@ -300,8 +300,8 @@ def get_inverse_fourier(self):
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
-            item = self.datadict[f'{key}_selected']
+        if f"{key}_selected" in self.datadict:
+            item = self.datadict[f"{key}_selected"]
         if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         x_values = np.array(item.xdata)
@@ -325,8 +325,8 @@ def combine_data(self):
     new_xdata = []
     new_ydata = []
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
-            item = self.datadict[f'{key}_selected']
+        if f"{key}_selected" in self.datadict:
+            item = self.datadict[f"{key}_selected"]
         if self.interaction_mode != InteractionMode.SELECT:
             item = self.datadict[key]
         new_xdata.extend(item.xdata.copy())
@@ -335,7 +335,7 @@ def combine_data(self):
     # Create the sample itself
     new_xdata, new_ydata = sort_data(new_xdata, new_ydata)
     new_item = Data(self, new_xdata, new_ydata)
-    new_item.filename = 'Combined Data'
+    new_item.filename = "Combined Data"
     filename_list = utilities.get_all_filenames(self)
 
     if new_item.filename in filename_list:
@@ -355,9 +355,9 @@ def smoothen_data(self):
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
+        if f"{key}_selected" in self.datadict:
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
             selected_item.ydata = smooth(selected_item.ydata, 4)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -378,7 +378,7 @@ def smooth(y_data, box_points):
     values are used for smoothening. Returns smoothened array
     """
     box = np.ones(box_points) / box_points
-    y_smooth = np.convolve(y_data, box, mode='same')
+    y_smooth = np.convolve(y_data, box, mode="same")
     return y_smooth
 
 
@@ -395,9 +395,9 @@ def shift_vertically(self):
         _selection, start_stop = select_data(self)
 
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
+        if f"{key}_selected" in self.datadict:
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             ymin = min(x for x in selected_item.ydata if x != 0)
             ymax = max(x for x in selected_item.ydata if x != 0)
             shift_value_linear += 1.2 * (ymax - ymin)
@@ -421,15 +421,15 @@ def shift_vertically(self):
 def shift_item(self, item, shift_value_log, shift_value_linear):
     # Check which axes the data is on, so it can choose the appropriate
     # scaling (log/linear)
-    if item.plot_Y_position == 'left':
-        if self.plot_settings.yscale == 'log':
+    if item.plot_Y_position == "left":
+        if self.plot_settings.yscale == "log":
             item.ydata = [value * shift_value_log for value in item.ydata]
-        if self.plot_settings.yscale == 'linear':
+        if self.plot_settings.yscale == "linear":
             item.ydata = [value + shift_value_linear for value in item.ydata]
-    if item.plot_Y_position == 'right':
-        if self.plot_settings.right_scale == 'log':
+    if item.plot_Y_position == "right":
+        if self.plot_settings.right_scale == "log":
             item.ydata = [value * shift_value_log for value in item.ydata]
-        if self.plot_settings.right_scale == 'linear':
+        if self.plot_settings.right_scale == "linear":
             item.ydata = [value + shift_value_linear for value in item.ydata]
 
 
@@ -445,16 +445,16 @@ def translate_x(self):
         offset = eval(win.translate_x_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f'{exception}: Unable to do translation, make sure to enter a valid number')
-        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do translation, make sure to enter a valid number'))
+        print(f"{exception}: Unable to do translation, make sure to enter a valid number")
+        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do translation, make sure to enter a valid number"))
         offset = 0
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     selected_keys = utilities.get_selected_keys(self)
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
+        if f"{key}_selected" in self.datadict:
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
             selected_item.xdata = [value + offset for value in selected_item.xdata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -480,8 +480,8 @@ def translate_y(self):
         offset = eval(win.translate_y_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f'{exception}: Unable to do translation, make sure to enter a valid number')
-        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do translation, make sure to enter a valid number'))
+        print(f"{exception}: Unable to do translation, make sure to enter a valid number")
+        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do translation, make sure to enter a valid number"))
         offset = 0
     selected_keys = utilities.get_selected_keys(self)
 
@@ -489,11 +489,11 @@ def translate_y(self):
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we're not in selection mode
-        if f'{key}_selected' in self.datadict:
+        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        if f"{key}_selected" in self.datadict:
             print(self.datadict[key].filename)
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
             selected_item.ydata = [value + offset for value in selected_item.ydata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -519,17 +519,17 @@ def multiply_x(self):
         multiplier = eval(win.multiply_x_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f'{exception}: Unable to do multiplication, make sure to enter a valid number')
-        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
+        print(f"{exception}: Unable to do multiplication, make sure to enter a valid number")
+        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do multiplication, make sure to enter a valid number"))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we're not in selection mode
-        if f'{key}_selected' in self.datadict:
+        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        if f"{key}_selected" in self.datadict:
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
             selected_item.xdata = [value * multiplier for value in selected_item.xdata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -555,17 +555,17 @@ def multiply_y(self):
         multiplier = eval(win.multiply_y_entry.get_text())
     except Exception as exception:
         exception_type = exception.__class__.__name__
-        print(f'{exception}: Unable to do multiplication, make sure to enter a valid number')
-        win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
+        print(f"{exception}: Unable to do multiplication, make sure to enter a valid number")
+        win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do multiplication, make sure to enter a valid number"))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we're not in selection mode
-        if f'{key}_selected' in self.datadict:
+        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        if f"{key}_selected" in self.datadict:
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
             selected_item.ydata = [value * multiplier for value in selected_item.ydata]
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -584,10 +584,10 @@ def normalize_data(self):
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we're not in selection mode
-        if f'{key}_selected' in self.datadict:
+        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        if f"{key}_selected" in self.datadict:
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
             selected_item.ydata = normalize(selected_item.ydata)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -621,14 +621,14 @@ def center_data(self):
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
     for key in selected_keys:
-        # If the selected data exists, so this will get ignored when we're not in selection mode
-        if f'{key}_selected' in self.datadict:
+        # If the selected data exists, so this will get ignored when we"re not in selection mode
+        if f"{key}_selected" in self.datadict:
             # Define the highlighted area
-            selected_item = self.datadict[f'{key}_selected']
+            selected_item = self.datadict[f"{key}_selected"]
             # Perform the operation on the highlighted area
-            if self.preferences.config['action_center_data'] == 'Center at maximum Y value':
+            if self.preferences.config["action_center_data"] == "Center at maximum Y value":
                 selected_item.xdata = center_data_max_y(selected_item.xdata, selected_item.ydata)
-            elif self.preferences.config['action_center_data'] == 'Center at middle coordinate':
+            elif self.preferences.config["action_center_data"] == "Center at middle coordinate":
                 selected_item.xdata = center_data_middle(selected_item.xdata)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             # Replace the highlighted part in the original data set
@@ -636,9 +636,9 @@ def center_data(self):
             self.datadict[key].xdata[start_index:stop_index] = selected_item.xdata
             self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
         if self.interaction_mode != InteractionMode.SELECT:
-            if self.preferences.config['action_center_data'] == 'Center at maximum Y value':
+            if self.preferences.config["action_center_data"] == "Center at maximum Y value":
                 self.datadict[key].xdata = center_data_max_y(self.datadict[key].xdata, self.datadict[key].ydata)
-            elif self.preferences.config['action_center_data'] == 'Center at middle coordinate':
+            elif self.preferences.config["action_center_data"] == "Center at middle coordinate":
                 self.datadict[key].xdata = center_data_middle(self.datadict[key].xdata)
             self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
     delete_selected_data(self)

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -122,9 +122,7 @@ def sort_data(x_values, y_values):
 
 
 def cut_data(self):
-    """
-    Cut selected data over the span that is selected
-    """
+    """Cut selected data over the span that is selected"""
     if self.interaction_mode == InteractionMode.SELECT:
         if select_data(self):  # If select_data ran succesfully
             for key, item in self.datadict.items():
@@ -234,9 +232,7 @@ def get_fraction_at_value(value, start, end):
 
 
 def get_derivative(self):
-    """
-    Calculate derivative of all selected data
-    """
+    """Calculate derivative of all selected data"""
     if self.interaction_mode == InteractionMode.SELECT:
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
@@ -256,9 +252,7 @@ def get_derivative(self):
 
 
 def get_integral(self):
-    """
-    Calculate indefinite integral of all selected data
-    """
+    """Calculate indefinite integral of all selected data"""
     if self.interaction_mode == InteractionMode.SELECT:
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
@@ -279,9 +273,7 @@ def get_integral(self):
 
 
 def get_fourier(self):
-    """
-    Perform Fourier transformation on all selected data
-    """
+    """Perform Fourier transformation on all selected data"""
     if self.interaction_mode == InteractionMode.SELECT:
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
@@ -303,9 +295,7 @@ def get_fourier(self):
 
 
 def get_inverse_fourier(self):
-    """
-    Perform Inverse Fourier transformation on all selected data
-    """
+    """Perform Inverse Fourier transformation on all selected data"""
     if self.interaction_mode == InteractionMode.SELECT:
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
@@ -327,9 +317,7 @@ def get_inverse_fourier(self):
 
 
 def combine_data(self):
-    """
-    Combine the selected data into a new data set
-    """
+    """Combine the selected data into a new data set"""
     if self.interaction_mode == InteractionMode.SELECT:
         select_data(self)
     selected_keys = utilities.get_selected_keys(self)
@@ -362,9 +350,7 @@ def combine_data(self):
 
 
 def smoothen_data(self):
-    """
-    Smoothen y-data.
-    """
+    """Smoothen y-data."""
     selected_keys = utilities.get_selected_keys(self)
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)
@@ -593,9 +579,7 @@ def multiply_y(self):
 
 
 def normalize_data(self):
-    """
-    Normalize all selected data
-    """
+    """Normalize all selected data"""
     selected_keys = utilities.get_selected_keys(self)
     if self.interaction_mode == InteractionMode.SELECT:
         _selection, start_stop = select_data(self)

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -109,13 +109,13 @@ def pick_data_selection(self, item, startx, stopx):
         return selected_data, start_index, stop_index
 
 
-def sort_data(x, y):
+def sort_data(x_values, y_values):
     """
     Sort x and y-coordinates such that the x-data is continiously increasing
     Takes in x, and y coordinates of that array, and returns the sorted variant
     """
-    zipped_list = zip(x, y)
-    sorted_lists = sorted(zipped_list, key=lambda x: x[0])
+    zipped_list = zip(x_values, y_values)
+    sorted_lists = sorted(zipped_list, key=lambda x_values: x_values[0])
     sorted_x, sorted_y = zip(*sorted_lists)
     return list(sorted_x), list(sorted_y)
 
@@ -244,9 +244,9 @@ def get_derivative(self):
             item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
-        x = np.array(item.xdata)
-        y = np.array(item.ydata)
-        dy_dx = np.gradient(y, x)
+        x_values = np.array(item.xdata)
+        y_values = np.array(item.ydata)
+        dy_dx = np.gradient(y_values, x_values)
         self.datadict[key].xdata = item.xdata
         self.datadict[key].ydata = dy_dx.tolist()
     add_to_clipboard(self)
@@ -266,11 +266,11 @@ def get_integral(self):
             item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
-        x = np.array(item.xdata)
-        y = np.array(item.ydata)
-        F = integrate.cumtrapz(y, x, initial=0)
+        x_values = np.array(item.xdata)
+        y_values = np.array(item.ydata)
+        indefinite_integral = integrate.cumtrapz(y_values, x_values, initial=0)
         self.datadict[key].xdata = item.xdata
-        self.datadict[key].ydata = F.tolist()
+        self.datadict[key].ydata = indefinite_integral.tolist()
 
     add_to_clipboard(self)
     delete_selected_data(self)
@@ -289,10 +289,10 @@ def get_fourier(self):
             item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
-        x = np.array(item.xdata)
-        y = np.array(item.ydata)
-        y_fourier = np.fft.fft(y)
-        x_fourier = np.fft.fftfreq(len(x), x[1] - x[0])
+        x_values = np.array(item.xdata)
+        y_values = np.array(item.ydata)
+        y_fourier = np.fft.fft(y_values)
+        x_fourier = np.fft.fftfreq(len(x_values), x_values[1] - x_values[0])
         y_fourier = [value.real for value in y_fourier]
         self.datadict[key].ydata = y_fourier
         self.datadict[key].xdata = x_fourier
@@ -313,10 +313,10 @@ def get_inverse_fourier(self):
             item = self.datadict[f'{key}_selected']
         if self._mode != InteractionMode.SELECT:
             item = self.datadict[key]
-        x = np.array(item.xdata)
-        y = np.array(item.ydata)
-        y_fourier = np.fft.ifft(y)
-        x_fourier = np.fft.fftfreq(len(x), x[1] - x[0])
+        x_values = np.array(item.xdata)
+        y_values = np.array(item.ydata)
+        y_fourier = np.fft.ifft(y_values)
+        x_fourier = np.fft.fftfreq(len(x_values), x_values[1] - x_values[0])
         y_fourier = [value.real for value in y_fourier]
         self.datadict[key].ydata = y_fourier
         self.datadict[key].xdata = x_fourier
@@ -456,9 +456,9 @@ def translate_x(self):
     win = self.main_window
     try:
         offset = eval(win.translate_x_entry.get_text())
-    except Exception as e:
-        exception_type = e.__class__.__name__
-        print(f'{e}: Unable to do translation, make sure to enter a valid number')
+    except Exception as exception:
+        exception_type = exception.__class__.__name__
+        print(f'{exception}: Unable to do translation, make sure to enter a valid number')
         win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do translation, make sure to enter a valid number'))
         offset = 0
     if self._mode == InteractionMode.SELECT:
@@ -491,9 +491,9 @@ def translate_y(self):
     win = self.main_window
     try:
         offset = eval(win.translate_y_entry.get_text())
-    except Exception as e:
-        exception_type = e.__class__.__name__
-        print(f'{e}: Unable to do translation, make sure to enter a valid number')
+    except Exception as exception:
+        exception_type = exception.__class__.__name__
+        print(f'{exception}: Unable to do translation, make sure to enter a valid number')
         win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do translation, make sure to enter a valid number'))
         offset = 0
     selected_keys = utilities.get_selected_keys(self)
@@ -530,9 +530,9 @@ def multiply_x(self):
     win = self.main_window
     try:
         multiplier = eval(win.multiply_x_entry.get_text())
-    except Exception as e:
-        exception_type = e.__class__.__name__
-        print(f'{e}: Unable to do multiplication, make sure to enter a valid number')
+    except Exception as exception:
+        exception_type = exception.__class__.__name__
+        print(f'{exception}: Unable to do multiplication, make sure to enter a valid number')
         win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
@@ -566,9 +566,9 @@ def multiply_y(self):
     win = self.main_window
     try:
         multiplier = eval(win.multiply_y_entry.get_text())
-    except Exception as e:
-        exception_type = e.__class__.__name__
-        print(f'{e}: Unable to do multiplication, make sure to enter a valid number')
+    except Exception as exception:
+        exception_type = exception.__class__.__name__
+        print(f'{exception}: Unable to do multiplication, make sure to enter a valid number')
         win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do multiplication, make sure to enter a valid number'))
         multiplier = 1
     selected_keys = utilities.get_selected_keys(self)
@@ -642,7 +642,7 @@ def center_data(self):
             selected_item = self.datadict[f'{key}_selected']
             # Perform the operation on the highlighted area
             if self.preferences.config['action_center_data'] == 'Center at maximum Y value':
-                selected_item.xdata = center_data_max_Y(selected_item.xdata, selected_item.ydata)
+                selected_item.xdata = center_data_max_y(selected_item.xdata, selected_item.ydata)
             elif self.preferences.config['action_center_data'] == 'Center at middle coordinate':
                 selected_item.xdata = center_data_middle(selected_item.xdata)
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
@@ -652,7 +652,7 @@ def center_data(self):
             self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
         if self._mode != InteractionMode.SELECT:
             if self.preferences.config['action_center_data'] == 'Center at maximum Y value':
-                self.datadict[key].xdata = center_data_max_Y(self.datadict[key].xdata, self.datadict[key].ydata)
+                self.datadict[key].xdata = center_data_max_y(self.datadict[key].xdata, self.datadict[key].ydata)
             elif self.preferences.config['action_center_data'] == 'Center at middle coordinate':
                 self.datadict[key].xdata = center_data_middle(self.datadict[key].xdata)
             self.datadict[key].xdata, self.datadict[key].ydata = sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
@@ -661,7 +661,7 @@ def center_data(self):
     plotting_tools.refresh_plot(self)
 
 
-def center_data_max_Y(xdata, ydata):
+def center_data_max_y(xdata, ydata):
     """
     Center data on the maximum y value, takes in x array and y array.
     Centers the x-data at index where the y-data has its maximum

--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,7 @@ class GraphsApplication(Adw.Application):
         self.issues = args[5]
         self.author = args[6]
         self.datadict = {}
-        self.filename = ''
+        self.filename = ""
         self.highlight = None
         self.highlights = []
         self.item_rows = {}
@@ -44,70 +44,70 @@ class GraphsApplication(Adw.Application):
     def connect_actions(self):
         """Create actions, which are defined in actions.py."""
         new_actions = [
-            ('quit', ['<primary>q']),
-            ('about', None),
-            ('preferences', ['<primary>p']),
-            ('plot_settings', ['<primary><shift>P']),
-            ('add_data', ['<primary>N']),
-            ('add_data_advanced', ['<primary><shift>N']),
-            ('add_equation', ['<primary><alt>N']),
-            ('select_all', ['<primary>A']),
-            ('select_none', ['<primary><shift>A']),
-            ('undo', ['<primary>Z']),
-            ('redo', ['<primary><shift>Z']),
-            ('restore_view', ['<primary>R']),
-            ('view_back', ['<alt>Z']),
-            ('view_forward', ['<alt><shift>Z']),
-            ('export_data', ['<primary><shift>E']),
-            ('export_figure', ['<primary>E']),
-            ('save_project', ['<primary>S']),
-            ('open_project', ['<primary>O']),
-            ('delete_selected', ['Delete']),
-            ('translate_x', None),
-            ('translate_y', None),
-            ('multiply_x', None),
-            ('multiply_y', None),
-            ('normalize', None),
-            ('smoothen', None),
-            ('center', None),
-            ('shift_vertically', None),
-            ('combine', None),
-            ('cut_selected', None),
-            ('get_derivative', None),
-            ('get_integral', None),
-            ('get_fourier', None),
-            ('get_inverse_fourier', None)
+            ("quit", ["<primary>q"]),
+            ("about", None),
+            ("preferences", ["<primary>p"]),
+            ("plot_settings", ["<primary><shift>P"]),
+            ("add_data", ["<primary>N"]),
+            ("add_data_advanced", ["<primary><shift>N"]),
+            ("add_equation", ["<primary><alt>N"]),
+            ("select_all", ["<primary>A"]),
+            ("select_none", ["<primary><shift>A"]),
+            ("undo", ["<primary>Z"]),
+            ("redo", ["<primary><shift>Z"]),
+            ("restore_view", ["<primary>R"]),
+            ("view_back", ["<alt>Z"]),
+            ("view_forward", ["<alt><shift>Z"]),
+            ("export_data", ["<primary><shift>E"]),
+            ("export_figure", ["<primary>E"]),
+            ("save_project", ["<primary>S"]),
+            ("open_project", ["<primary>O"]),
+            ("delete_selected", ["Delete"]),
+            ("translate_x", None),
+            ("translate_y", None),
+            ("multiply_x", None),
+            ("multiply_y", None),
+            ("normalize", None),
+            ("smoothen", None),
+            ("center", None),
+            ("shift_vertically", None),
+            ("combine", None),
+            ("cut_selected", None),
+            ("get_derivative", None),
+            ("get_integral", None),
+            ("get_fourier", None),
+            ("get_inverse_fourier", None)
         ]
         methods = {}
-        for key, item in getmembers(globals().copy()['actions'], isfunction):
+        for key, item in getmembers(globals().copy()["actions"], isfunction):
             methods[key] = item
         for name, keybinds in new_actions:
             action = Gio.SimpleAction.new(name, None)
-            action.connect('activate', methods[f'{name}_action'], self)
+            action.connect("activate", methods[f"{name}_action"], self)
             self.add_action(action)
             if keybinds:
-                self.set_accels_for_action(f'app.{name}', keybinds)
+                self.set_accels_for_action(f"app.{name}", keybinds)
 
-        self.create_axis_action('change_left_yscale', plotting_tools.change_left_yscale, 'plot_Y_scale')
-        self.create_axis_action('change_right_yscale', plotting_tools.change_right_yscale, 'plot_right_scale')
-        self.create_axis_action('change_top_xscale', plotting_tools.change_top_xscale, 'plot_top_scale')
-        self.create_axis_action('change_bottom_xscale', plotting_tools.change_bottom_xscale, 'plot_X_scale')
+        self.create_axis_action("change_left_yscale", plotting_tools.change_left_yscale, "plot_Y_scale")
+        self.create_axis_action("change_right_yscale", plotting_tools.change_right_yscale, "plot_right_scale")
+        self.create_axis_action("change_top_xscale", plotting_tools.change_top_xscale, "plot_top_scale")
+        self.create_axis_action("change_bottom_xscale", plotting_tools.change_bottom_xscale, "plot_X_scale")
 
-        toggle_sidebar = Gio.SimpleAction.new_stateful('toggle_sidebar', None, GLib.Variant.new_boolean(True))
-        toggle_sidebar.connect('activate', ui.toggle_sidebar, self)
+        toggle_sidebar = Gio.SimpleAction.new_stateful("toggle_sidebar", None, GLib.Variant.new_boolean(True))
+        toggle_sidebar.connect("activate", ui.toggle_sidebar, self)
         self.add_action(toggle_sidebar)
-        self.set_accels_for_action('app.toggle_sidebar', ['F9'])
+        self.set_accels_for_action("app.toggle_sidebar", ["F9"])
 
-        self.create_mode_action('mode_pan', ['<shift>P', 'F1'], InteractionMode.PAN)
-        self.create_mode_action('mode_zoom', ['<shift>Z', 'F2'], InteractionMode.ZOOM)
-        self.create_mode_action('mode_select', ['<shift>S', 'F3'], InteractionMode.SELECT)
+        self.create_mode_action("mode_pan", ["<shift>P", "F1"], InteractionMode.PAN)
+        self.create_mode_action("mode_zoom", ["<shift>Z", "F2"], InteractionMode.ZOOM)
+        self.create_mode_action("mode_select", ["<shift>S", "F3"], InteractionMode.SELECT)
 
-        Adw.StyleManager.get_default().connect('notify', ui.toggle_darkmode, None, self)
+        Adw.StyleManager.get_default().connect("notify", ui.toggle_darkmode, None, self)
 
     def do_activate(self):
         """Called when the application is activated.
 
-        We raise the application's main window, creating it if
+        We raise the application"s main window, creating it if
         necessary.
         """
         win = self.props.active_window
@@ -162,20 +162,20 @@ class GraphsApplication(Adw.Application):
 
     def create_axis_action(self, name, callback, config_key):
         """Create action for setting axis scale."""
-        action = Gio.SimpleAction.new_stateful(name, GLib.VariantType.new('s'), GLib.Variant.new_string(self.preferences.config[config_key]))
-        action.connect('activate', callback, self)
+        action = Gio.SimpleAction.new_stateful(name, GLib.VariantType.new("s"), GLib.Variant.new_string(self.preferences.config[config_key]))
+        action.connect("activate", callback, self)
         self.add_action(action)
 
     def create_mode_action(self, name, shortcuts, mode):
         """Create action for mode setting."""
         action = Gio.SimpleAction.new(name, None)
-        action.connect('activate', self.set_mode, mode)
+        action.connect("activate", self.set_mode, mode)
         self.add_action(action)
-        self.set_accels_for_action(f'app.{name}', shortcuts)
+        self.set_accels_for_action(f"app.{name}", shortcuts)
 
 
 def main(args):
-    """The application's entry point."""
+    """The application"s entry point."""
     app = GraphsApplication(args)
 
     return app.run(sys.argv)

--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ class GraphsApplication(Adw.Application):
 
     def load_preferences(self):
         """Load preferences."""
-        plotting_tools.load_fonts(self)
+        plotting_tools.load_fonts()
         self.preferences = preferences.Preferences(self)
         self.plot_settings = plotting_tools.PlotSettings(self)
 
@@ -157,7 +157,7 @@ class GraphsApplication(Adw.Application):
             highlight.set_active(True)
         for axis in self.canvas.figure.get_axes():
             axis.set_navigate_mode(self.dummy_toolbar.mode._navigate_mode)
-        self._mode = mode
+        self.interaction_mode = mode
         self.canvas.draw()
 
     def create_axis_action(self, name, callback, config_key):

--- a/src/main.py
+++ b/src/main.py
@@ -88,21 +88,35 @@ class GraphsApplication(Adw.Application):
             if keybinds:
                 self.set_accels_for_action(f"app.{name}", keybinds)
 
-        self.create_axis_action("change_left_yscale", plotting_tools.change_left_yscale, "plot_Y_scale")
-        self.create_axis_action("change_right_yscale", plotting_tools.change_right_yscale, "plot_right_scale")
-        self.create_axis_action("change_top_xscale", plotting_tools.change_top_xscale, "plot_top_scale")
-        self.create_axis_action("change_bottom_xscale", plotting_tools.change_bottom_xscale, "plot_X_scale")
+        self.create_axis_action("change_left_yscale",
+                                plotting_tools.change_left_yscale,
+                                "plot_Y_scale")
+        self.create_axis_action("change_right_yscale",
+                                plotting_tools.change_right_yscale,
+                                "plot_right_scale")
+        self.create_axis_action("change_top_xscale",
+                                plotting_tools.change_top_xscale,
+                                "plot_top_scale")
+        self.create_axis_action("change_bottom_xscale",
+                                plotting_tools.change_bottom_xscale,
+                                "plot_X_scale")
 
-        toggle_sidebar = Gio.SimpleAction.new_stateful("toggle_sidebar", None, GLib.Variant.new_boolean(True))
+        state = GLib.Variant.new_boolean(True)
+        toggle_sidebar = Gio.SimpleAction.new_stateful("toggle_sidebar",
+                                                       None, state)
         toggle_sidebar.connect("activate", ui.toggle_sidebar, self)
         self.add_action(toggle_sidebar)
         self.set_accels_for_action("app.toggle_sidebar", ["F9"])
 
-        self.create_mode_action("mode_pan", ["<shift>P", "F1"], InteractionMode.PAN)
-        self.create_mode_action("mode_zoom", ["<shift>Z", "F2"], InteractionMode.ZOOM)
-        self.create_mode_action("mode_select", ["<shift>S", "F3"], InteractionMode.SELECT)
+        self.create_mode_action("mode_pan", ["<shift>P", "F1"],
+                                InteractionMode.PAN)
+        self.create_mode_action("mode_zoom", ["<shift>Z", "F2"],
+                                InteractionMode.ZOOM)
+        self.create_mode_action("mode_select", ["<shift>S", "F3"],
+                                InteractionMode.SELECT)
 
-        Adw.StyleManager.get_default().connect("notify", ui.toggle_darkmode, None, self)
+        Adw.StyleManager.get_default().connect("notify",
+                                               ui.toggle_darkmode, None, self)
 
     def do_activate(self):
         """Called when the application is activated.
@@ -162,7 +176,9 @@ class GraphsApplication(Adw.Application):
 
     def create_axis_action(self, name, callback, config_key):
         """Create action for setting axis scale."""
-        action = Gio.SimpleAction.new_stateful(name, GLib.VariantType.new("s"), GLib.Variant.new_string(self.preferences.config[config_key]))
+        config = self.preferences.config[config_key]
+        action = Gio.SimpleAction.new_stateful(
+            name, GLib.VariantType.new("s"), GLib.Variant.new_string(config))
         action.connect("activate", callback, self)
         self.add_action(action)
 

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ class GraphsApplication(Adw.Application):
         super().__init__(application_id='se.sjoerd.Graphs',
                          flags=Gio.ApplicationFlags.FLAGS_NONE)
         self.datadict = dict()        
-        self.filename = ""
+        self.filename = ''
         self.highlight = None
         self.highlights = []        
         self.item_rows = dict()
@@ -37,7 +37,7 @@ class GraphsApplication(Adw.Application):
         ('quit', ['<primary>q']),
         ('about', None),
         ('preferences', ['<primary>p']),
-        ('plot_settings', ["<primary><shift>P"]),
+        ('plot_settings', ['<primary><shift>P']),
         ('add_data', ['<primary>N']),
         ('add_data_advanced', ['<primary><shift>N']),
         ('add_equation', ['<primary><alt>N']),
@@ -49,7 +49,7 @@ class GraphsApplication(Adw.Application):
         ('view_back', ['<alt>Z']),
         ('view_forward', ['<alt><shift>Z']),
         ('export_data', ['<primary><shift>E']),
-        ('export_figure', ["<primary>E"]),
+        ('export_figure', ['<primary>E']),
         ('save_project', ['<primary>S']),
         ('open_project', ['<primary>O']),
         ('delete_selected', ['Delete']),
@@ -69,30 +69,30 @@ class GraphsApplication(Adw.Application):
         ('get_inverse_fourier', None)
         ]
         methods = dict()
-        for key, item in getmembers(globals().copy()["actions"], isfunction):
+        for key, item in getmembers(globals().copy()['actions'], isfunction):
             methods[key] = item
         for name, keybinds in new_actions:
             action = Gio.SimpleAction.new(name, None)
-            action.connect("activate", methods[f'{name}_action'], self)
+            action.connect('activate', methods[f'{name}_action'], self)
             self.add_action(action)
             if keybinds:
-                self.set_accels_for_action(f"app.{name}", keybinds)
+                self.set_accels_for_action(f'app.{name}', keybinds)
 
         self.create_axis_action('change_left_yscale', plotting_tools.change_left_yscale, 'plot_Y_scale')
         self.create_axis_action('change_right_yscale', plotting_tools.change_right_yscale, 'plot_right_scale')
         self.create_axis_action('change_top_xscale', plotting_tools.change_top_xscale, 'plot_top_scale')
         self.create_axis_action('change_bottom_xscale', plotting_tools.change_bottom_xscale, 'plot_X_scale')
 
-        toggle_sidebar = Gio.SimpleAction.new_stateful("toggle_sidebar", None, GLib.Variant.new_boolean(True))
-        toggle_sidebar.connect("activate", ui.toggle_sidebar, self)
+        toggle_sidebar = Gio.SimpleAction.new_stateful('toggle_sidebar', None, GLib.Variant.new_boolean(True))
+        toggle_sidebar.connect('activate', ui.toggle_sidebar, self)
         self.add_action(toggle_sidebar)
-        self.set_accels_for_action("app.toggle_sidebar", ['F9'])
+        self.set_accels_for_action('app.toggle_sidebar', ['F9'])
 
         self.create_mode_action('mode_pan', ['<shift>P', 'F1'], InteractionMode.PAN)
         self.create_mode_action('mode_zoom', ['<shift>Z', 'F2'], InteractionMode.ZOOM)
         self.create_mode_action('mode_select', ['<shift>S', 'F3'], InteractionMode.SELECT)
 
-        Adw.StyleManager.get_default().connect("notify", ui.toggle_darkmode, None, self)
+        Adw.StyleManager.get_default().connect('notify', ui.toggle_darkmode, None, self)
 
     def do_activate(self):
         """Called when the application is activated
@@ -152,15 +152,15 @@ class GraphsApplication(Adw.Application):
         self.canvas.draw()
 
     def create_axis_action(self, name, callback, config_key):
-        action = Gio.SimpleAction.new_stateful(name, GLib.VariantType.new("s"), GLib.Variant.new_string(self.preferences.config[config_key]))
-        action.connect("activate", callback, self)
+        action = Gio.SimpleAction.new_stateful(name, GLib.VariantType.new('s'), GLib.Variant.new_string(self.preferences.config[config_key]))
+        action.connect('activate', callback, self)
         self.add_action(action)
 
     def create_mode_action(self, name, shortcuts, mode):
         action = Gio.SimpleAction.new(name, None)
-        action.connect("activate", self.set_mode, mode)
+        action.connect('activate', self.set_mode, mode)
         self.add_action(action)
-        self.set_accels_for_action(f"app.{name}", shortcuts)
+        self.set_accels_for_action(f'app.{name}', shortcuts)
 
 
 def main(version, appid, name, copyright, website, issues, author):

--- a/src/main.py
+++ b/src/main.py
@@ -163,16 +163,16 @@ class GraphsApplication(Adw.Application):
         self.set_accels_for_action(f'app.{name}', shortcuts)
 
 
-def main(version, appid, name, copyright, website, issues, author):
+def main(args):
     """The application's entry point."""
     app = GraphsApplication()
-    app.version = version
-    app.appid = appid
-    app.name = name
-    app.copyright = copyright
-    app.website = website
-    app.issues = issues
-    app.author = author
+    app.version = args[0]
+    app.appid = args[1]
+    app.name = args[2]
+    app.copyright = args[3]
+    app.website = args[4]
+    app.issues = args[5]
+    app.author = args[6]
 
     return app.run(sys.argv)
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -29,9 +29,11 @@ class InteractionMode(Enum):
 
 
 class DummyToolbar(NavigationToolbar2):
-    """Own implementation of NavigationToolbar2. Needed for rubberband support."""
+    """Own implementation of NavigationToolbar2 for rubberband support."""
     def draw_rubberband(self, _event, x_0, y_0, x_1, y_1):
-        self.canvas._rubberband_rect = [int(val) for val in (x_0, self.canvas.figure.bbox.height - y_0, x_1 - x_0, y_0 - y_1)]
+        self.canvas._rubberband_rect = [int(val) for val in (x_0,
+                                        self.canvas.figure.bbox.height - y_0,
+                                        x_1 - x_0, y_0 - y_1)]
         self.canvas.queue_draw()
 
     def remove_rubberband(self):

--- a/src/misc.py
+++ b/src/misc.py
@@ -5,14 +5,14 @@ from matplotlib.backend_bases import NavigationToolbar2
 class ImportSettings():
     def __init__(self, parent):
         cfg = parent.preferences.config
-        self.name = ""
-        self.path = ""
-        self.delimiter = cfg["import_delimiter"]
-        self.guess_headers = cfg["guess_headers"]
-        self.separator = cfg["import_separator"]
-        self.skip_rows = cfg["import_skip_rows"]
-        self.column_x = cfg["import_column_x"]
-        self.column_y = cfg["import_column_y"]
+        self.name = ''
+        self.path = ''
+        self.delimiter = cfg['import_delimiter']
+        self.guess_headers = cfg['guess_headers']
+        self.separator = cfg['import_separator']
+        self.skip_rows = cfg['import_skip_rows']
+        self.column_x = cfg['import_column_x']
+        self.column_y = cfg['import_column_y']
 
 class ImportMode(Enum):
     SINGLE = 1

--- a/src/misc.py
+++ b/src/misc.py
@@ -33,7 +33,7 @@ class DummyToolbar(NavigationToolbar2):
     Own implementation of NavigationToolbar2. Needed for rubberband support.
     """
     def draw_rubberband(self, event, x_0, y_0, x_1, y_1):
-        self.canvas._rubberband_rect = [int(val) for val in (x0, self.canvas.figure.bbox.height - y_0, x_1 - x_0, y_0 - y_1)]
+        self.canvas._rubberband_rect = [int(val) for val in (x_0, self.canvas.figure.bbox.height - y_0, x_1 - x_0, y_0 - y_1)]
         self.canvas.queue_draw()
 
     def remove_rubberband(self):

--- a/src/misc.py
+++ b/src/misc.py
@@ -29,9 +29,7 @@ class InteractionMode(Enum):
 
 
 class DummyToolbar(NavigationToolbar2):
-    """
-    Own implementation of NavigationToolbar2. Needed for rubberband support.
-    """
+    """Own implementation of NavigationToolbar2. Needed for rubberband support."""
     def draw_rubberband(self, _event, x_0, y_0, x_1, y_1):
         self.canvas._rubberband_rect = [int(val) for val in (x_0, self.canvas.figure.bbox.height - y_0, x_1 - x_0, y_0 - y_1)]
         self.canvas.queue_draw()

--- a/src/misc.py
+++ b/src/misc.py
@@ -32,7 +32,7 @@ class DummyToolbar(NavigationToolbar2):
     """
     Own implementation of NavigationToolbar2. Needed for rubberband support.
     """
-    def draw_rubberband(self, event, x_0, y_0, x_1, y_1):
+    def draw_rubberband(self, _event, x_0, y_0, x_1, y_1):
         self.canvas._rubberband_rect = [int(val) for val in (x_0, self.canvas.figure.bbox.height - y_0, x_1 - x_0, y_0 - y_1)]
         self.canvas.queue_draw()
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from enum import Enum
+
 from matplotlib.backend_bases import NavigationToolbar2
+
 
 class ImportSettings():
     def __init__(self, parent):
@@ -14,14 +16,17 @@ class ImportSettings():
         self.column_x = cfg['import_column_x']
         self.column_y = cfg['import_column_y']
 
+
 class ImportMode(Enum):
     SINGLE = 1
     MULTIPLE = 2
+
 
 class InteractionMode(Enum):
     PAN = 1
     ZOOM = 2
     SELECT = 3
+
 
 class DummyToolbar(NavigationToolbar2):
     """
@@ -37,4 +42,3 @@ class DummyToolbar(NavigationToolbar2):
     def remove_rubberband(self):
         self.canvas._rubberband_rect = None
         self.canvas.queue_draw()
-

--- a/src/misc.py
+++ b/src/misc.py
@@ -35,8 +35,8 @@ class DummyToolbar(NavigationToolbar2):
     def __init__(self, canvas):
         super().__init__(canvas)
 
-    def draw_rubberband(self, event, x0, y0, x1, y1):
-        self.canvas._rubberband_rect = [int(val) for val in (x0, self.canvas.figure.bbox.height - y0, x1 - x0, y0 - y1)]
+    def draw_rubberband(self, event, x_0, y_0, x_1, y_1):
+        self.canvas._rubberband_rect = [int(val) for val in (x0, self.canvas.figure.bbox.height - y_0, x_1 - x_0, y_0 - y_1)]
         self.canvas.queue_draw()
 
     def remove_rubberband(self):

--- a/src/misc.py
+++ b/src/misc.py
@@ -7,14 +7,14 @@ from matplotlib.backend_bases import NavigationToolbar2
 class ImportSettings():
     def __init__(self, parent):
         cfg = parent.preferences.config
-        self.name = ''
-        self.path = ''
-        self.delimiter = cfg['import_delimiter']
-        self.guess_headers = cfg['guess_headers']
-        self.separator = cfg['import_separator']
-        self.skip_rows = cfg['import_skip_rows']
-        self.column_x = cfg['import_column_x']
-        self.column_y = cfg['import_column_y']
+        self.name = ""
+        self.path = ""
+        self.delimiter = cfg["import_delimiter"]
+        self.guess_headers = cfg["guess_headers"]
+        self.separator = cfg["import_separator"]
+        self.skip_rows = cfg["import_skip_rows"]
+        self.column_x = cfg["import_column_x"]
+        self.column_y = cfg["import_column_y"]
 
 
 class ImportMode(Enum):

--- a/src/misc.py
+++ b/src/misc.py
@@ -32,9 +32,6 @@ class DummyToolbar(NavigationToolbar2):
     """
     Own implementation of NavigationToolbar2. Needed for rubberband support.
     """
-    def __init__(self, canvas):
-        super().__init__(canvas)
-
     def draw_rubberband(self, event, x_0, y_0, x_1, y_1):
         self.canvas._rubberband_rect = [int(val) for val in (x0, self.canvas.figure.bbox.height - y_0, x_1 - x_0, y_0 - y_1)]
         self.canvas.queue_draw()

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -7,13 +7,6 @@ import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
 
-def open_plot_settings(self, key=None):
-    win = PlotSettingsWindow(self, key)
-    win.set_transient_for(self.props.active_window)
-    win.set_modal(True)
-    win.present()
-
-
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/plot_settings.ui')
 class PlotSettingsWindow(Adw.PreferencesWindow):
     __gtype_name__ = 'PlotSettingsWindow'
@@ -51,7 +44,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
     plot_legend_check = Gtk.Template.Child()
     plot_font_chooser = Gtk.Template.Child()
 
-    def __init__(self, parent, key):
+    def __init__(self, parent, key=None):
         super().__init__()
         self.select_item = False
         self.chooser_changed = True
@@ -60,6 +53,8 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.item = self.load_config(parent, key)
         self.datalist_chooser.connect('notify::selected', self.on_notify, parent)
         self.connect('close-request', self.on_close, parent)
+        self.set_transient_for(parent.main_window)
+        self.set_modal(True)
 
     def get_chooser_list(self, chooser):
         model = chooser.get_model()

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -7,9 +7,9 @@ import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/plot_settings.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/plot_settings.ui")
 class PlotSettingsWindow(Adw.PreferencesWindow):
-    __gtype_name__ = 'PlotSettingsWindow'
+    __gtype_name__ = "PlotSettingsWindow"
     datalist_chooser = Gtk.Template.Child()
     name_entry = Gtk.Template.Child()
     linestyle_selected = Gtk.Template.Child()
@@ -51,8 +51,8 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         filenames = utilities.get_all_filenames(parent)
         utilities.populate_chooser(self.datalist_chooser, filenames)
         self.item = self.load_config(parent, key)
-        self.datalist_chooser.connect('notify::selected', self.on_notify, parent)
-        self.connect('close-request', self.on_close, parent)
+        self.datalist_chooser.connect("notify::selected", self.on_notify, parent)
+        self.connect("close-request", self.on_close, parent)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)
 
@@ -66,7 +66,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
     def on_notify(self, _, __, parent):
         self.save_settings(parent)
         filenames = utilities.get_all_filenames(parent)
-        self.name_entry.set_text('')
+        self.name_entry.set_text("")
         index = self.datalist_chooser.get_selected()
         if set(filenames) != set(self.get_chooser_list(self.datalist_chooser)):
             utilities.populate_chooser(self.datalist_chooser, filenames)
@@ -138,7 +138,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         return item
 
     def set_config(self, item, parent):
-        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(' ')
+        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(" ")
         font_size = font_name[-1]
         font_weight = utilities.get_font_weight(font_name)
         font_style = utilities.get_font_style(font_name)
@@ -167,7 +167,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         parent.plot_settings.right_scale = self.plot_right_scale.get_selected_item().get_string()
         parent.plot_settings.top_scale = self.plot_top_scale.get_selected_item().get_string()
         parent.plot_settings.plot_style = self.plot_style.get_selected_item().get_string()
-        if self.name_entry.get_text() != '':
+        if self.name_entry.get_text() != "":
             item.filename = self.name_entry.get_text()
         item.plot_Y_position = self.plot_Y_position.get_selected_item().get_string()
         item.plot_X_position = self.plot_X_position.get_selected_item().get_string()
@@ -189,7 +189,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         new_item = self.set_config(item, parent)
         max_length = int(26)
         if len(new_item.filename) > max_length:
-            label = f'{new_item.filename[:max_length]}...'
+            label = f"{new_item.filename[:max_length]}..."
         else:
             label = new_item.filename
         parent.item_rows[new_item.key].sample_id_label.set_text(label)

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -51,7 +51,8 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         filenames = utilities.get_all_filenames(parent)
         utilities.populate_chooser(self.datalist_chooser, filenames)
         self.item = self.load_config(parent, key)
-        self.datalist_chooser.connect("notify::selected", self.on_notify, parent)
+        self.datalist_chooser.connect(
+            "notify::selected", self.on_notify, parent)
         self.connect("close-request", self.on_close, parent)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)
@@ -82,7 +83,8 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.datalist_chooser.set_selected(index)
         item = parent.datadict[data_list[index]]
         font_string = parent.plot_settings.font_string
-        font_desc = self.plot_font_chooser.get_font_desc().from_string(font_string)
+        font_desc = self.plot_font_chooser.get_font_desc().from_string(
+            font_string)
         self.plot_font_chooser.set_font_desc(font_desc)
         self.plot_font_chooser.set_use_font(True)
         self.selected_line_thickness_slider.set_range(0.1, 10)
@@ -98,32 +100,48 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.plot_X_label.set_text(parent.plot_settings.xlabel)
         self.plot_right_label.set_text(parent.plot_settings.right_label)
         self.plot_top_label.set_text(parent.plot_settings.top_label)
-        self.plot_minor_tick_width.set_value(parent.plot_settings.minor_tick_width)
-        self.plot_major_tick_width.set_value(parent.plot_settings.major_tick_width)
-        self.plot_minor_tick_length.set_value(parent.plot_settings.minor_tick_length)
-        self.plot_major_tick_length.set_value(parent.plot_settings.major_tick_length)
+        self.plot_minor_tick_width.set_value(
+            parent.plot_settings.minor_tick_width)
+        self.plot_major_tick_width.set_value(
+            parent.plot_settings.major_tick_width)
+        self.plot_minor_tick_length.set_value(
+            parent.plot_settings.minor_tick_length)
+        self.plot_major_tick_length.set_value(
+            parent.plot_settings.major_tick_length)
         utilities.set_chooser(self.plot_Y_position, item.plot_y_position)
         utilities.set_chooser(self.plot_X_position, item.plot_x_position)
         utilities.set_chooser(self.plot_X_scale, parent.plot_settings.xscale)
         utilities.set_chooser(self.plot_Y_scale, parent.plot_settings.yscale)
-        utilities.set_chooser(self.plot_right_scale, parent.plot_settings.right_scale)
-        utilities.set_chooser(self.plot_top_scale, parent.plot_settings.top_scale)
-        utilities.set_chooser(self.plot_tick_direction, parent.plot_settings.tick_direction)
+        utilities.set_chooser(
+            self.plot_right_scale, parent.plot_settings.right_scale)
+        utilities.set_chooser(
+            self.plot_top_scale, parent.plot_settings.top_scale)
+        utilities.set_chooser(
+            self.plot_tick_direction, parent.plot_settings.tick_direction)
         utilities.set_chooser(self.linestyle_selected, item.linestyle_selected)
-        utilities.set_chooser(self.linestyle_unselected, item.linestyle_unselected)
-        self.selected_line_thickness_slider.set_value(item.selected_line_thickness)
-        self.unselected_line_thickness_slider.set_value(item.unselected_line_thickness)
+        utilities.set_chooser(
+            self.linestyle_unselected, item.linestyle_unselected)
+        self.selected_line_thickness_slider.set_value(
+            item.selected_line_thickness)
+        self.unselected_line_thickness_slider.set_value(
+            item.unselected_line_thickness)
         self.selected_marker_size.set_value(item.selected_marker_size)
         self.unselected_marker_size.set_value(item.unselected_marker_size)
-        utilities.populate_chooser(self.selected_markers_chooser, list(Line2D.markers.values()), clear=False)
+        utilities.populate_chooser(
+            self.selected_markers_chooser,
+            list(Line2D.markers.values()), clear=False)
         utilities.populate_chooser(self.plot_style, plt.style.available)
-        utilities.populate_chooser(self.unselected_markers_chooser, list(Line2D.markers.values()), clear=False)
+        utilities.populate_chooser(
+            self.unselected_markers_chooser,
+            list(Line2D.markers.values()), clear=False)
         utilities.set_chooser(self.plot_style, parent.plot_settings.plot_style)
         marker_dict = Line2D.markers
         unselected_marker_value = marker_dict[item.unselected_markers]
         selected_marker_value = marker_dict[item.selected_markers]
-        utilities.set_chooser(self.selected_markers_chooser, selected_marker_value)
-        utilities.set_chooser(self.unselected_markers_chooser, unselected_marker_value)
+        utilities.set_chooser(
+            self.selected_markers_chooser, selected_marker_value)
+        utilities.set_chooser(
+            self.unselected_markers_chooser, unselected_marker_value)
         self.item = item
         if parent.plot_settings.tick_left:
             self.plot_tick_left.set_active(True)
@@ -138,50 +156,76 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         return item
 
     def set_config(self, item, parent):
-        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(" ")
+        plot_settings = parent.plot_settings
+        font_name = self.plot_font_chooser.get_font_desc(
+        ).to_string().lower().split(" ")
         font_size = font_name[-1]
         font_weight = utilities.get_font_weight(font_name)
         font_style = utilities.get_font_style(font_name)
-        parent.plot_settings.font_size = font_size
-        parent.plot_settings.font_style = font_style
-        parent.plot_settings.font_weight = font_weight
-        parent.plot_settings.font_string = self.plot_font_chooser.get_font_desc().to_string()
-        parent.plot_settings.font_family = self.plot_font_chooser.get_font_desc().get_family()
-        parent.plot_settings.legend = self.plot_legend_check.get_active()
-        parent.plot_settings.title = self.plot_title.get_text()
-        parent.plot_settings.tick_left = self.plot_tick_left.get_active()
-        parent.plot_settings.tick_right = self.plot_tick_right.get_active()
-        parent.plot_settings.tick_top = self.plot_tick_top.get_active()
-        parent.plot_settings.tick_bottom = self.plot_tick_bottom.get_active()
-        parent.plot_settings.major_tick_width = self.plot_major_tick_width.get_value()
-        parent.plot_settings.minor_tick_width = self.plot_minor_tick_width.get_value()
-        parent.plot_settings.major_tick_length = self.plot_major_tick_length.get_value()
-        parent.plot_settings.minor_tick_length = self.plot_minor_tick_length.get_value()
-        parent.plot_settings.tick_direction = self.plot_tick_direction.get_selected_item().get_string()
-        parent.plot_settings.ylabel = self.plot_Y_label.get_text()
-        parent.plot_settings.xlabel = self.plot_X_label.get_text()
-        parent.plot_settings.right_label = self.plot_right_label.get_text()
-        parent.plot_settings.top_label = self.plot_top_label.get_text()
-        parent.plot_settings.xscale = self.plot_X_scale.get_selected_item().get_string()
-        parent.plot_settings.yscale = self.plot_Y_scale.get_selected_item().get_string()
-        parent.plot_settings.right_scale = self.plot_right_scale.get_selected_item().get_string()
-        parent.plot_settings.top_scale = self.plot_top_scale.get_selected_item().get_string()
-        parent.plot_settings.plot_style = self.plot_style.get_selected_item().get_string()
+        plot_settings.font_size = font_size
+        plot_settings.font_style = font_style
+        plot_settings.font_weight = font_weight
+        font_description = self.plot_font_chooser.get_font_desc()
+        plot_settings.font_string = font_description.to_string()
+        plot_settings.font_family = font_description.get_family()
+        plot_settings.legend = self.plot_legend_check.get_active()
+        plot_settings.title = self.plot_title.get_text()
+        plot_settings.tick_left = self.plot_tick_left.get_active()
+        plot_settings.tick_right = self.plot_tick_right.get_active()
+        plot_settings.tick_top = self.plot_tick_top.get_active()
+        plot_settings.tick_bottom = self.plot_tick_bottom.get_active()
+        plot_settings.major_tick_width = self.plot_major_tick_width.get_value()
+        plot_settings.minor_tick_width = self.plot_minor_tick_width.get_value()
+        plot_major_tick_length = self.plot_major_tick_length
+        plot_settings.major_tick_length = plot_major_tick_length.get_value()
+        plot_minor_tick_length = self.plot_minor_tick_length
+        plot_settings.minor_tick_length = plot_minor_tick_length.get_value()
+        selected_item = self.plot_tick_direction.get_selected_item()
+        plot_settings.tick_direction = selected_item.get_string()
+        plot_settings.ylabel = self.plot_Y_label.get_text()
+        plot_settings.xlabel = self.plot_X_label.get_text()
+        plot_settings.right_label = self.plot_right_label.get_text()
+        plot_settings.top_label = self.plot_top_label.get_text()
+        plot_settings.xscale = self.plot_X_scale.get_selected_item(
+        ).get_string()
+        plot_settings.yscale = self.plot_Y_scale.get_selected_item(
+        ).get_string()
+        plot_settings.right_scale = self.plot_right_scale.get_selected_item(
+        ).get_string()
+        plot_settings.top_scale = self.plot_top_scale.get_selected_item(
+        ).get_string()
+        plot_settings.plot_style = self.plot_style.get_selected_item(
+        ).get_string()
         if self.name_entry.get_text() != "":
             item.filename = self.name_entry.get_text()
-        item.plot_Y_position = self.plot_Y_position.get_selected_item().get_string()
-        item.plot_X_position = self.plot_X_position.get_selected_item().get_string()
-        item.linestyle_selected = self.linestyle_selected.get_selected_item().get_string()
-        item.linestyle_unselected = self.linestyle_unselected.get_selected_item().get_string()
-        item.selected_markers = self.selected_markers_chooser.get_selected_item().get_string()
-        item.unselected_markers = self.unselected_markers_chooser.get_selected_item().get_string()
-        item.selected_line_thickness = self.selected_line_thickness_slider.get_value()
-        item.unselected_line_thickness = self.unselected_line_thickness_slider.get_value()
+        item.plot_Y_position = self.plot_Y_position.get_selected_item(
+        ).get_string()
+        item.plot_X_position = self.plot_X_position.get_selected_item(
+        ).get_string()
+        item.linestyle_selected = self.linestyle_selected.get_selected_item(
+        ).get_string()
+        linestyle_unselected = self.linestyle_unselected
+        item.linestyle_unselected = linestyle_unselected.get_selected_item(
+        ).get_string()
+        selected_markers = self.selected_markers_chooser
+        item.selected_markers = selected_markers.get_selected_item(
+        ).get_string()
+        unselected_markers = self.unselected_markers_chooser
+        item.unselected_markers = unselected_markers.get_selected_item(
+        ).get_string()
+        selected_slider = self.selected_line_thickness_slider
+        item.selected_line_thickness = selected_slider.get_value()
+        unselected_slider = self.unselected_line_thickness_slider
+        item.unselected_line_thickness = unselected_slider.get_value()
         item.selected_marker_size = self.selected_marker_size.get_value()
         item.unselected_marker_size = self.unselected_marker_size.get_value()
         marker_dict = Line2D.markers
-        item.selected_markers = utilities.get_dict_by_value(marker_dict, self.selected_markers_chooser.get_selected_item().get_string())
-        item.unselected_markers = utilities.get_dict_by_value(marker_dict, self.unselected_markers_chooser.get_selected_item().get_string())
+        item.selected_markers = utilities.get_dict_by_value(
+            marker_dict,
+            self.selected_markers_chooser.get_selected_item().get_string())
+        item.unselected_markers = utilities.get_dict_by_value(
+            marker_dict,
+            self.unselected_markers_chooser.get_selected_item().get_string())
         return item
 
     def save_settings(self, parent):

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -14,9 +14,9 @@ def open_plot_settings(self, key = None):
     win.present()
 
 
-@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/plot_settings.ui")
+@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/plot_settings.ui')
 class PlotSettingsWindow(Adw.PreferencesWindow):
-    __gtype_name__ = "PlotSettingsWindow"
+    __gtype_name__ = 'PlotSettingsWindow'
     datalist_chooser = Gtk.Template.Child()
     name_entry = Gtk.Template.Child()
     linestyle_selected = Gtk.Template.Child()
@@ -58,8 +58,8 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         filenames = utilities.get_all_filenames(parent)
         utilities.populate_chooser(self.datalist_chooser, filenames)
         self.item = self.load_config(parent, key)
-        self.datalist_chooser.connect("notify::selected", self.on_notify, parent)
-        self.connect("close-request", self.on_close, parent)
+        self.datalist_chooser.connect('notify::selected', self.on_notify, parent)
+        self.connect('close-request', self.on_close, parent)
         
     def get_chooser_list(self, chooser):
         model = chooser.get_model()
@@ -72,7 +72,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
     def on_notify(self, _, __, parent):
         self.save_settings(parent)
         filenames = utilities.get_all_filenames(parent)
-        self.name_entry.set_text("")
+        self.name_entry.set_text('')
         index = self.datalist_chooser.get_selected()
         if set(filenames) != set(self.get_chooser_list(self.datalist_chooser)):
             utilities.populate_chooser(self.datalist_chooser, filenames)
@@ -144,7 +144,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         return item
 
     def set_config(self, item, parent):
-        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(" ")
+        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(' ')
         font_size = font_name[-1]
         font_weight = utilities.get_font_weight(font_name)
         font_style = utilities.get_font_style(font_name)
@@ -173,7 +173,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         parent.plot_settings.right_scale = self.plot_right_scale.get_selected_item().get_string()
         parent.plot_settings.top_scale = self.plot_top_scale.get_selected_item().get_string()
         parent.plot_settings.plot_style = self.plot_style.get_selected_item().get_string()      
-        if self.name_entry.get_text() != "":
+        if self.name_entry.get_text() != '':
             item.filename = self.name_entry.get_text()
         item.plot_Y_position = self.plot_Y_position.get_selected_item().get_string()
         item.plot_X_position = self.plot_X_position.get_selected_item().get_string()
@@ -195,7 +195,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         new_item = self.set_config(item, parent)
         max_length = int(26)
         if len(new_item.filename) > max_length:
-            label = f"{new_item.filename[:max_length]}..."
+            label = f'{new_item.filename[:max_length]}...'
         else:
             label = new_item.filename
         parent.item_rows[new_item.key].sample_ID_label.set_text(label)

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -107,8 +107,8 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.plot_major_tick_width.set_value(parent.plot_settings.major_tick_width)
         self.plot_minor_tick_length.set_value(parent.plot_settings.minor_tick_length)
         self.plot_major_tick_length.set_value(parent.plot_settings.major_tick_length)
-        utilities.set_chooser(self.plot_Y_position, item.plot_Y_position)
-        utilities.set_chooser(self.plot_X_position, item.plot_X_position)
+        utilities.set_chooser(self.plot_Y_position, item.plot_y_position)
+        utilities.set_chooser(self.plot_X_position, item.plot_x_position)
         utilities.set_chooser(self.plot_X_scale, parent.plot_settings.xscale)
         utilities.set_chooser(self.plot_Y_scale, parent.plot_settings.yscale)
         utilities.set_chooser(self.plot_right_scale, parent.plot_settings.right_scale)
@@ -197,7 +197,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
             label = f'{new_item.filename[:max_length]}...'
         else:
             label = new_item.filename
-        parent.item_rows[new_item.key].sample_ID_label.set_text(label)
+        parent.item_rows[new_item.key].sample_id_label.set_text(label)
         if new_item.selected:
             graphs.select_item(parent, new_item.key)
 

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Gtk, Adw
+from gi.repository import Adw, Gtk
 
-from matplotlib.lines import Line2D
+from graphs import graphs, plotting_tools, utilities
+
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
 
-from . import plotting_tools, graphs, utilities
-from .data import Data
 
-def open_plot_settings(self, key = None):
+def open_plot_settings(self, key=None):
     win = PlotSettingsWindow(self, key)
     win.set_transient_for(self.props.active_window)
     win.set_modal(True)
@@ -60,15 +60,14 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.item = self.load_config(parent, key)
         self.datalist_chooser.connect('notify::selected', self.on_notify, parent)
         self.connect('close-request', self.on_close, parent)
-        
+
     def get_chooser_list(self, chooser):
         model = chooser.get_model()
         chooser_list = []
         for item in model:
             chooser_list.append(item.get_string())
         return chooser_list
-        
-            
+
     def on_notify(self, _, __, parent):
         self.save_settings(parent)
         filenames = utilities.get_all_filenames(parent)
@@ -77,7 +76,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         if set(filenames) != set(self.get_chooser_list(self.datalist_chooser)):
             utilities.populate_chooser(self.datalist_chooser, filenames)
         self.datalist_chooser.set_selected(index)
-        self.load_config(parent, key = None)
+        self.load_config(parent, key=None)
         self.chooser_changed = False
 
     def load_config(self, parent, key):
@@ -121,9 +120,9 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.unselected_line_thickness_slider.set_value(item.unselected_line_thickness)
         self.selected_marker_size.set_value(item.selected_marker_size)
         self.unselected_marker_size.set_value(item.unselected_marker_size)
-        utilities.populate_chooser(self.selected_markers_chooser, list(Line2D.markers.values()), clear = False)
+        utilities.populate_chooser(self.selected_markers_chooser, list(Line2D.markers.values()), clear=False)
         utilities.populate_chooser(self.plot_style, plt.style.available)
-        utilities.populate_chooser(self.unselected_markers_chooser, list(Line2D.markers.values()), clear = False)
+        utilities.populate_chooser(self.unselected_markers_chooser, list(Line2D.markers.values()), clear=False)
         utilities.set_chooser(self.plot_style, parent.plot_settings.plot_style)
         marker_dict = Line2D.markers
         unselected_marker_value = marker_dict[item.unselected_markers]
@@ -156,9 +155,9 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         parent.plot_settings.legend = self.plot_legend_check.get_active()
         parent.plot_settings.title = self.plot_title.get_text()
         parent.plot_settings.tick_left = self.plot_tick_left.get_active()
-        parent.plot_settings.tick_right  = self.plot_tick_right.get_active()
-        parent.plot_settings.tick_top  = self.plot_tick_top.get_active()
-        parent.plot_settings.tick_bottom  = self.plot_tick_bottom.get_active()
+        parent.plot_settings.tick_right = self.plot_tick_right.get_active()
+        parent.plot_settings.tick_top = self.plot_tick_top.get_active()
+        parent.plot_settings.tick_bottom = self.plot_tick_bottom.get_active()
         parent.plot_settings.major_tick_width = self.plot_major_tick_width.get_value()
         parent.plot_settings.minor_tick_width = self.plot_minor_tick_width.get_value()
         parent.plot_settings.major_tick_length = self.plot_major_tick_length.get_value()
@@ -166,13 +165,13 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         parent.plot_settings.tick_direction = self.plot_tick_direction.get_selected_item().get_string()
         parent.plot_settings.ylabel = self.plot_Y_label.get_text()
         parent.plot_settings.xlabel = self.plot_X_label.get_text()
-        parent.plot_settings.right_label = self.plot_right_label.get_text()      
-        parent.plot_settings.top_label = self.plot_top_label.get_text()      
+        parent.plot_settings.right_label = self.plot_right_label.get_text()
+        parent.plot_settings.top_label = self.plot_top_label.get_text()
         parent.plot_settings.xscale = self.plot_X_scale.get_selected_item().get_string()
         parent.plot_settings.yscale = self.plot_Y_scale.get_selected_item().get_string()
         parent.plot_settings.right_scale = self.plot_right_scale.get_selected_item().get_string()
         parent.plot_settings.top_scale = self.plot_top_scale.get_selected_item().get_string()
-        parent.plot_settings.plot_style = self.plot_style.get_selected_item().get_string()      
+        parent.plot_settings.plot_style = self.plot_style.get_selected_item().get_string()
         if self.name_entry.get_text() != '':
             item.filename = self.name_entry.get_text()
         item.plot_Y_position = self.plot_Y_position.get_selected_item().get_string()
@@ -189,7 +188,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         item.selected_markers = utilities.get_dict_by_value(marker_dict, self.selected_markers_chooser.get_selected_item().get_string())
         item.unselected_markers = utilities.get_dict_by_value(marker_dict, self.unselected_markers_chooser.get_selected_item().get_string())
         return item
-        
+
     def save_settings(self, parent):
         item = self.item
         new_item = self.set_config(item, parent)
@@ -205,4 +204,3 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
     def on_close(self, _, parent):
         self.save_settings(parent)
         plotting_tools.reload_plot(parent)
-

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -15,14 +15,14 @@ def define_highlight(self, span=None):
     Create a span selector object, to highlight part of the graph.
     If a span already exists, make it visible instead
     """
-    color = utilities.lookup_color(self, 'accent_color')
+    color = utilities.lookup_color(self, "accent_color")
     self.highlight = SpanSelector(
         self.canvas.top_right_axis,
         lambda x, y: on_highlight_define(self),
-        'horizontal',
+        "horizontal",
         useblit=True,
-        props={'facecolor': (color.red, color.green, color.blue, 0.3), 'edgecolor': (color.red, color.green, color.blue, 1), 'linewidth': 1},
-        handle_props={'linewidth': 0},
+        props={"facecolor": (color.red, color.green, color.blue, 0.3), "edgecolor": (color.red, color.green, color.blue, 1), "linewidth": 1},
+        handle_props={"linewidth": 0},
         interactive=True,
         drag_from_anywhere=True)
     if span is not None:
@@ -31,7 +31,7 @@ def define_highlight(self, span=None):
 
 def on_highlight_define(self):
     """
-    This ensures that the span selector doesn't go out of range
+    This ensures that the span selector doesn"t go out of range
     There are some obscure cases where this otherwise happens, and the selection
     tool becomes unusable.
     """
@@ -46,22 +46,22 @@ def on_highlight_define(self):
     self.highlight.extents = (extend_min, extend_max)
 
 
-def plot_figure(self, canvas, x_data, y_data, filename='', linewidth=2, marker=None, linestyle='solid',
-                color=None, marker_size=10, y_axis='left', x_axis='bottom'):
+def plot_figure(self, canvas, x_data, y_data, filename="", linewidth=2, marker=None, linestyle="solid",
+                color=None, marker_size=10, y_axis="left", x_axis="bottom"):
     """
     Plot the figure on the graph
     Necessary input arguments are self, the canvas to plot the figure on and the
     X and Y data
     """
-    if y_axis == 'left':
-        if x_axis == 'bottom':
+    if y_axis == "left":
+        if x_axis == "bottom":
             canvas.ax.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
-        elif x_axis == 'top':
+        elif x_axis == "top":
             canvas.top_left_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
-    elif y_axis == 'right':
-        if x_axis == 'bottom':
+    elif y_axis == "right":
+        if x_axis == "bottom":
             canvas.right_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
-        elif x_axis == 'top':
+        elif x_axis == "top":
             canvas.top_right_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
             canvas.top_right_axis.set_yscale(self.plot_settings.right_scale)
     set_legend(self, canvas)
@@ -83,46 +83,46 @@ def set_canvas_limits_axis(self):
     used_axes, item_list = get_used_axes(self)
 
     for axis in used_axes:
-        if axis == 'left':
+        if axis == "left":
             left_items = []
-            for key in item_list['left']:
+            for key in item_list["left"]:
                 left_items.append(key)
             left_limits = find_limits(self, self.canvas.ax.get_yscale(), left_items)
-        if axis == 'right':
+        if axis == "right":
             right_items = []
-            for key in item_list['right']:
+            for key in item_list["right"]:
                 right_items.append(key)
             right_limits = find_limits(self, self.canvas.right_axis.get_yscale(), right_items)
-        if axis == 'top':
+        if axis == "top":
             top_items = []
-            for key in item_list['top']:
+            for key in item_list["top"]:
                 top_items.append(key)
             top_limits = find_limits(self, axis, top_items)
-        if axis == 'bottom':
+        if axis == "bottom":
             bottom_items = []
-            for key in item_list['bottom']:
+            for key in item_list["bottom"]:
                 bottom_items.append(key)
             bottom_limits = find_limits(self, axis, bottom_items)
-    if used_axes['left'] and used_axes['bottom']:
-        set_canvas_limits(left_limits, self.canvas.ax, axis_type='Y')
-        set_canvas_limits(bottom_limits, self.canvas.ax, axis_type='X')
-    if used_axes['left'] and used_axes['top']:
-        set_canvas_limits(left_limits, self.canvas.top_left_axis, axis_type='Y')
-        set_canvas_limits(top_limits, self.canvas.top_left_axis, axis_type='X')
-    if used_axes['right'] and used_axes['bottom']:
-        set_canvas_limits(right_limits, self.canvas.right_axis, axis_type='Y')
-        set_canvas_limits(bottom_limits, self.canvas.right_axis, axis_type='X')
-    if used_axes['right'] and used_axes['top']:
-        set_canvas_limits(right_limits, self.canvas.top_right_axis, axis_type='Y')
-        set_canvas_limits(top_limits, self.canvas.top_right_axis, axis_type='X')
+    if used_axes["left"] and used_axes["bottom"]:
+        set_canvas_limits(left_limits, self.canvas.ax, axis_type="Y")
+        set_canvas_limits(bottom_limits, self.canvas.ax, axis_type="X")
+    if used_axes["left"] and used_axes["top"]:
+        set_canvas_limits(left_limits, self.canvas.top_left_axis, axis_type="Y")
+        set_canvas_limits(top_limits, self.canvas.top_left_axis, axis_type="X")
+    if used_axes["right"] and used_axes["bottom"]:
+        set_canvas_limits(right_limits, self.canvas.right_axis, axis_type="Y")
+        set_canvas_limits(bottom_limits, self.canvas.right_axis, axis_type="X")
+    if used_axes["right"] and used_axes["top"]:
+        set_canvas_limits(right_limits, self.canvas.top_right_axis, axis_type="Y")
+        set_canvas_limits(top_limits, self.canvas.top_right_axis, axis_type="X")
 
 
 def get_used_axes(self):
     used_axis = {}
-    used_axis['left'] = False
-    used_axis['right'] = False
-    used_axis['top'] = False
-    used_axis['bottom'] = False
+    used_axis["left"] = False
+    used_axis["right"] = False
+    used_axis["top"] = False
+    used_axis["bottom"] = False
     item_list = {}
     left_items = []
     right_items = []
@@ -130,56 +130,56 @@ def get_used_axes(self):
     bottom_items = []
 
     for key, item in self.datadict.items():
-        if item.plot_y_position == 'left':
-            used_axis['left'] = True
+        if item.plot_y_position == "left":
+            used_axis["left"] = True
             left_items.append(key)
-        if item.plot_y_position == 'right':
-            used_axis['right'] = True
+        if item.plot_y_position == "right":
+            used_axis["right"] = True
             right_items.append(key)
-        if item.plot_x_position == 'top':
-            used_axis['top'] = True
+        if item.plot_x_position == "top":
+            used_axis["top"] = True
             top_items.append(key)
-        if item.plot_x_position == 'bottom':
-            used_axis['bottom'] = True
+        if item.plot_x_position == "bottom":
+            used_axis["bottom"] = True
             bottom_items.append(key)
-    item_list['left'] = left_items
-    item_list['right'] = right_items
-    item_list['top'] = top_items
-    item_list['bottom'] = bottom_items
+    item_list["left"] = left_items
+    item_list["right"] = right_items
+    item_list["top"] = top_items
+    item_list["bottom"] = bottom_items
     return used_axis, item_list
 
 
-def set_canvas_limits(graph_limits, axis, axis_type, limits={'xmin': None, 'xmax': None, 'ymin': None, 'ymax': None}):
+def set_canvas_limits(graph_limits, axis, axis_type, limits={"xmin": None, "xmax": None, "ymin": None, "ymax": None}):
     """Set an calculate the canvas limits for a given axis."""
     # Update graph limits with limits that were given as argument
     for key, item in limits.items():
         if item is not None:
             graph_limits[key] = item
-    x_span = (graph_limits['xmax'] - graph_limits['xmin'])
-    y_span = (graph_limits['ymax'] - graph_limits['ymin'])
-    if axis.get_xscale() == 'linear':
-        graph_limits['xmin'] -= 0.015 * x_span
-        graph_limits['xmax'] += 0.015 * x_span
-    if axis.get_yscale() == 'linear':
+    x_span = (graph_limits["xmax"] - graph_limits["xmin"])
+    y_span = (graph_limits["ymax"] - graph_limits["ymin"])
+    if axis.get_xscale() == "linear":
+        graph_limits["xmin"] -= 0.015 * x_span
+        graph_limits["xmax"] += 0.015 * x_span
+    if axis.get_yscale() == "linear":
         if y_span != 0:
-            if graph_limits['ymin'] > 0:
-                graph_limits['ymin'] *= 0.95
+            if graph_limits["ymin"] > 0:
+                graph_limits["ymin"] *= 0.95
             else:
-                graph_limits['ymin'] *= 1.05
-            graph_limits['ymax'] *= 1.05
+                graph_limits["ymin"] *= 1.05
+            graph_limits["ymax"] *= 1.05
         else:
-            graph_limits['ymax'] += abs(graph_limits['ymax'] * 0.05)
-            graph_limits['ymin'] -= abs(graph_limits['ymin'] * 0.05)
+            graph_limits["ymax"] += abs(graph_limits["ymax"] * 0.05)
+            graph_limits["ymin"] -= abs(graph_limits["ymin"] * 0.05)
     else:
-        graph_limits['ymin'] *= 0.5
-        graph_limits['ymax'] *= 2
+        graph_limits["ymin"] *= 0.5
+        graph_limits["ymax"] *= 2
     try:
-        if axis_type == 'X':
-            axis.set_xlim(graph_limits['xmin'], graph_limits['xmax'])
-        if axis_type == 'Y':
-            axis.set_ylim(graph_limits['ymin'], graph_limits['ymax'])
+        if axis_type == "X":
+            axis.set_xlim(graph_limits["xmin"], graph_limits["xmax"])
+        if axis_type == "Y":
+            axis.set_ylim(graph_limits["ymin"], graph_limits["ymax"])
     except ValueError:
-        print('Could not set limits, one of the values was probably infinite')
+        print("Could not set limits, one of the values was probably infinite")
 
 
 def find_limits(self, axis, datadict):
@@ -191,14 +191,14 @@ def find_limits(self, axis, datadict):
 
     for key in datadict:
         item = self.datadict[key]
-        # Check the limits of each item, as long as it exists and it has the same axes as the one we're adjusting right now
+        # Check the limits of each item, as long as it exists and it has the same axes as the one we"re adjusting right now
         if item is not None and len(item.xdata) > 0:
             # Nonzero ydata is needed for logs
             nonzero_ydata = list(filter(lambda x: (x != 0), item.ydata))
             xmin_item = min(item.xdata)
             xmax_item = max(item.xdata)
 
-            if axis == 'log' and len(nonzero_ydata) > 0:
+            if axis == "log" and len(nonzero_ydata) > 0:
                 ymin_item = min(nonzero_ydata)
             else:
                 ymin_item = min(item.ydata)
@@ -220,7 +220,7 @@ def find_limits(self, axis, datadict):
                 ymin_all = ymin_item
             if ymax_item > ymax_all:
                 ymax_all = ymax_item
-    return {'xmin': xmin_all, 'xmax': xmax_all, 'ymin': ymin_all, 'ymax': ymax_all}
+    return {"xmin": xmin_all, "xmax": xmax_all, "ymin": ymin_all, "ymax": ymax_all}
 
 
 def reload_plot(self):
@@ -269,13 +269,13 @@ def hide_unused_axes(self, canvas):
     top = False
     bottom = False
     for _key, item in self.datadict.items():
-        if item.plot_y_position == 'left':
+        if item.plot_y_position == "left":
             left = True
-        if item.plot_y_position == 'right':
+        if item.plot_y_position == "right":
             right = True
-        if item.plot_x_position == 'top':
+        if item.plot_x_position == "top":
             top = True
-        if item.plot_x_position == 'bottom':
+        if item.plot_x_position == "bottom":
             bottom = True
     if not left:
         canvas.top_left_axis.get_yaxis().set_visible(False)
@@ -297,12 +297,12 @@ def hide_unused_axes(self, canvas):
 
 
 def change_left_yscale(action, target, self):
-    if target.get_string() == 'log':
-        self.canvas.ax.set_yscale('log')
-        self.plot_settings.yscale = 'log'
+    if target.get_string() == "log":
+        self.canvas.ax.set_yscale("log")
+        self.plot_settings.yscale = "log"
     else:
-        self.canvas.ax.set_yscale('linear')
-        self.plot_settings.yscale = 'linear'
+        self.canvas.ax.set_yscale("linear")
+        self.plot_settings.yscale = "linear"
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self)
@@ -310,14 +310,14 @@ def change_left_yscale(action, target, self):
 
 
 def change_right_yscale(action, target, self):
-    if target.get_string() == 'log':
-        self.canvas.top_right_axis.set_yscale('log')
-        self.canvas.right_axis.set_yscale('log')
-        self.plot_settings.right_scale = 'log'
+    if target.get_string() == "log":
+        self.canvas.top_right_axis.set_yscale("log")
+        self.canvas.right_axis.set_yscale("log")
+        self.plot_settings.right_scale = "log"
     else:
-        self.canvas.top_right_axis.set_yscale('linear')
-        self.canvas.right_axis.set_yscale('linear')
-        self.plot_settings.right_scale = 'linear'
+        self.canvas.top_right_axis.set_yscale("linear")
+        self.canvas.right_axis.set_yscale("linear")
+        self.plot_settings.right_scale = "linear"
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self)
@@ -325,14 +325,14 @@ def change_right_yscale(action, target, self):
 
 
 def change_top_xscale(action, target, self):
-    if target.get_string() == 'log':
-        self.canvas.top_left_axis.set_xscale('log')
-        self.canvas.top_right_axis.set_xscale('log')
-        self.plot_settings.top_scale = 'log'
+    if target.get_string() == "log":
+        self.canvas.top_left_axis.set_xscale("log")
+        self.canvas.top_right_axis.set_xscale("log")
+        self.plot_settings.top_scale = "log"
     else:
-        self.canvas.top_left_axis.set_xscale('linear')
-        self.canvas.top_right_axis.set_xscale('linear')
-        self.plot_settings.top_scale = 'linear'
+        self.canvas.top_left_axis.set_xscale("linear")
+        self.canvas.top_right_axis.set_xscale("linear")
+        self.plot_settings.top_scale = "linear"
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self)
@@ -340,14 +340,14 @@ def change_top_xscale(action, target, self):
 
 
 def change_bottom_xscale(action, target, self):
-    if target.get_string() == 'log':
-        self.canvas.ax.set_xscale('log')
-        self.canvas.right_axis.set_xscale('log')
-        self.plot_settings.xscale = 'log'
+    if target.get_string() == "log":
+        self.canvas.ax.set_xscale("log")
+        self.canvas.right_axis.set_xscale("log")
+        self.plot_settings.xscale = "log"
     else:
-        self.canvas.ax.set_xscale('linear')
-        self.canvas.right_axis.set_xscale('linear')
-        self.plot_settings.xscale = 'linear'
+        self.canvas.ax.set_xscale("linear")
+        self.canvas.right_axis.set_xscale("linear")
+        self.plot_settings.xscale = "linear"
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self)
@@ -376,12 +376,12 @@ def get_next_color(self):
 
 def load_fonts():
     """Load system fonts that are installed on the system"""
-    font_list = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext='ttf')
+    font_list = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
     for font in font_list:
         try:
             matplotlib.font_manager.fontManager.addfont(font)
         except Exception:
-            print(f'Could not load {font}')
+            print(f"Could not load {font}")
 
 
 class PlotSettings:
@@ -390,31 +390,31 @@ class PlotSettings:
     retreived from the config file through preferences.
     """
     def __init__(self, parent):
-        self.font_string = parent.preferences.config['plot_font_string']
-        self.xlabel = parent.preferences.config['plot_X_label']
-        self.right_label = parent.preferences.config['plot_right_label']
-        self.top_label = parent.preferences.config['plot_top_label']
-        self.ylabel = parent.preferences.config['plot_Y_label']
-        self.xscale = parent.preferences.config['plot_X_scale']
-        self.yscale = parent.preferences.config['plot_Y_scale']
-        self.right_scale = parent.preferences.config['plot_right_scale']
-        self.top_scale = parent.preferences.config['plot_top_scale']
-        self.title = parent.preferences.config['plot_title']
-        self.font_weight = parent.preferences.config['plot_font_weight']
-        self.font_family = parent.preferences.config['plot_font_family']
-        self.font_size = parent.preferences.config['plot_font_size']
-        self.font_style = parent.preferences.config['plot_font_style']
-        self.tick_direction = parent.preferences.config['plot_tick_direction']
-        self.major_tick_length = parent.preferences.config['plot_major_tick_length']
-        self.minor_tick_length = parent.preferences.config['plot_minor_tick_length']
-        self.major_tick_width = parent.preferences.config['plot_major_tick_width']
-        self.minor_tick_width = parent.preferences.config['plot_minor_tick_width']
-        self.tick_top = parent.preferences.config['plot_tick_top']
-        self.tick_bottom = parent.preferences.config['plot_tick_bottom']
-        self.tick_left = parent.preferences.config['plot_tick_left']
-        self.tick_right = parent.preferences.config['plot_tick_right']
-        self.legend = parent.preferences.config['plot_legend']
+        self.font_string = parent.preferences.config["plot_font_string"]
+        self.xlabel = parent.preferences.config["plot_X_label"]
+        self.right_label = parent.preferences.config["plot_right_label"]
+        self.top_label = parent.preferences.config["plot_top_label"]
+        self.ylabel = parent.preferences.config["plot_Y_label"]
+        self.xscale = parent.preferences.config["plot_X_scale"]
+        self.yscale = parent.preferences.config["plot_Y_scale"]
+        self.right_scale = parent.preferences.config["plot_right_scale"]
+        self.top_scale = parent.preferences.config["plot_top_scale"]
+        self.title = parent.preferences.config["plot_title"]
+        self.font_weight = parent.preferences.config["plot_font_weight"]
+        self.font_family = parent.preferences.config["plot_font_family"]
+        self.font_size = parent.preferences.config["plot_font_size"]
+        self.font_style = parent.preferences.config["plot_font_style"]
+        self.tick_direction = parent.preferences.config["plot_tick_direction"]
+        self.major_tick_length = parent.preferences.config["plot_major_tick_length"]
+        self.minor_tick_length = parent.preferences.config["plot_minor_tick_length"]
+        self.major_tick_width = parent.preferences.config["plot_major_tick_width"]
+        self.minor_tick_width = parent.preferences.config["plot_minor_tick_width"]
+        self.tick_top = parent.preferences.config["plot_tick_top"]
+        self.tick_bottom = parent.preferences.config["plot_tick_bottom"]
+        self.tick_left = parent.preferences.config["plot_tick_left"]
+        self.tick_right = parent.preferences.config["plot_tick_right"]
+        self.legend = parent.preferences.config["plot_legend"]
         if Adw.StyleManager.get_default().get_dark():
-            self.plot_style = parent.preferences.config['plot_style_dark']
+            self.plot_style = parent.preferences.config["plot_style_dark"]
         else:
-            self.plot_style = parent.preferences.config['plot_style_light']
+            self.plot_style = parent.preferences.config["plot_style_light"]

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -68,9 +68,7 @@ def plot_figure(self, canvas, x_data, y_data, filename='', linewidth=2, marker=N
 
 
 def set_legend(self, canvas):
-    """
-    Set the legend of the graph
-    """
+    """Set the legend of the graph"""
     if self.plot_settings.legend:
         canvas.legends = []
         lines, labels = canvas.ax.get_legend_handles_labels()
@@ -81,9 +79,7 @@ def set_legend(self, canvas):
 
 
 def set_canvas_limits_axis(self):
-    """
-    Set the canvas limits for each axis that is present
-    """
+    """Set the canvas limits for each axis that is present"""
     used_axes, item_list = get_used_axes(self)
 
     for axis in used_axes:
@@ -154,9 +150,7 @@ def get_used_axes(self):
 
 
 def set_canvas_limits(graph_limits, axis, axis_type, limits={'xmin': None, 'xmax': None, 'ymin': None, 'ymax': None}):
-    """
-    Set an calculate the canvas limits for a given axis.
-    """
+    """Set an calculate the canvas limits for a given axis."""
     # Update graph limits with limits that were given as argument
     for key, item in limits.items():
         if item is not None:
@@ -189,9 +183,7 @@ def set_canvas_limits(graph_limits, axis, axis_type, limits={'xmin': None, 'xmax
 
 
 def find_limits(self, axis, datadict):
-    """
-    Find the limits that are to be used for the axes.
-    """
+    """Find the limits that are to be used for the axes."""
     xmin_all = None
     xmax_all = None
     ymin_all = None
@@ -232,9 +224,7 @@ def find_limits(self, axis, datadict):
 
 
 def reload_plot(self):
-    """
-    Completely reload the plot of the graph
-    """
+    """Completely reload the plot of the graph"""
     graphs.load_empty(self)
     if len(self.datadict) > 0:
         hide_unused_axes(self, self.canvas)
@@ -249,9 +239,7 @@ def reload_plot(self):
 
 
 def refresh_plot(self, canvas=None, set_limits=True):
-    """
-    Refresh the graph without completely reloading it.
-    """
+    """Refresh the graph without completely reloading it."""
     if canvas is None:
         canvas = self.canvas
     for line in canvas.ax.lines:
@@ -271,9 +259,7 @@ def refresh_plot(self, canvas=None, set_limits=True):
 
 
 def hide_unused_axes(self, canvas):
-    """
-    Hide axes that are not in use, to avoid unnecessary ticks in the plots.
-    """
+    """Hide axes that are not in use, to avoid unnecessary ticks in the plots."""
     # Double check the code here, seems to work but this is too messy
     for axis in [canvas.ax, canvas.right_axis, canvas.top_left_axis, canvas.top_right_axis]:
         axis.get_xaxis().set_visible(True)
@@ -369,9 +355,7 @@ def change_bottom_xscale(action, target, self):
 
 
 def get_next_color(self):
-    """
-    Get the color that is to be used for the next data set
-    """
+    """Get the color that is to be used for the next data set"""
     color_list = self.canvas.color_cycle
     used_colors = []
     item_rows = copy.copy(self.item_rows)
@@ -391,9 +375,7 @@ def get_next_color(self):
 
 
 def load_fonts():
-    """
-    Load system fonts that are installed on the system
-    """
+    """Load system fonts that are installed on the system"""
     font_list = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext='ttf')
     for font in font_list:
         try:

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -134,16 +134,16 @@ def get_used_axes(self):
     bottom_items = []
 
     for key, item in self.datadict.items():
-        if item.plot_Y_position == 'left':
+        if item.plot_y_position == 'left':
             used_axis['left'] = True
             left_items.append(key)
-        if item.plot_Y_position == 'right':
+        if item.plot_y_position == 'right':
             used_axis['right'] = True
             right_items.append(key)
-        if item.plot_X_position == 'top':
+        if item.plot_x_position == 'top':
             used_axis['top'] = True
             top_items.append(key)
-        if item.plot_X_position == 'bottom':
+        if item.plot_x_position == 'bottom':
             used_axis['bottom'] = True
             bottom_items.append(key)
     item_list['left'] = left_items
@@ -283,13 +283,13 @@ def hide_unused_axes(self, canvas):
     top = False
     bottom = False
     for key, item in self.datadict.items():
-        if item.plot_Y_position == 'left':
+        if item.plot_y_position == 'left':
             left = True
-        if item.plot_Y_position == 'right':
+        if item.plot_y_position == 'right':
             right = True
-        if item.plot_X_position == 'top':
+        if item.plot_x_position == 'top':
             top = True
-        if item.plot_X_position == 'bottom':
+        if item.plot_x_position == 'bottom':
             bottom = True
     if not left:
         canvas.top_left_axis.get_yaxis().set_visible(False)

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import copy
-import os
-import matplotlib.font_manager
 
-from gi.repository import Gtk, Adw
+from gi.repository import Adw
+
+from graphs import graphs, utilities
+
+import matplotlib.font_manager
 from matplotlib import colors
 from matplotlib.widgets import SpanSelector
 
-from . import graphs, utilities
 
 def define_highlight(self, span=None):
     """
@@ -20,12 +21,13 @@ def define_highlight(self, span=None):
         lambda x, y: on_highlight_define(self),
         'horizontal',
         useblit=True,
-        props=dict(facecolor = (color.red, color.green, color.blue, 0.3), edgecolor = (color.red, color.green, color.blue, 1), linewidth = 1),
-        handle_props=dict(linewidth=0),
+        props={(color.red, color.green, color.blue, 0.3), (color.red, color.green, color.blue, 1), 1},
+        handle_props={0},
         interactive=True,
         drag_from_anywhere=True)
     if span is not None:
         self.highlight.extents = span
+
 
 def on_highlight_define(self):
     """
@@ -36,15 +38,16 @@ def on_highlight_define(self):
     xmin = min(self.canvas.top_right_axis.get_xlim())
     xmax = max(self.canvas.top_right_axis.get_xlim())
     extend_min = self.highlight.extents[0]
-    extend_max = self.highlight.extents[1]    
+    extend_max = self.highlight.extents[1]
     if self.highlight.extents[0] < xmin:
         extend_min = xmin
     if self.highlight.extents[1] > xmax:
-        extend_max = xmax  
+        extend_max = xmax
     self.highlight.extents = (extend_min, extend_max)
 
-def plot_figure(self, canvas, X, Y, filename=', xlim=None, linewidth = 2, title=', scale='log',marker=None, linestyle='solid',
-                     revert = False, color = None, marker_size = 10, y_axis = 'left', x_axis = 'bottom'):
+
+def plot_figure(self, canvas, X, Y, filename='', xlim=None, linewidth=2, title='', scale='log', marker=None, linestyle='solid',
+                revert=False, color=None, marker_size=10, y_axis='left', x_axis='bottom'):
     """
     Plot the figure on the graph
     Necessary input arguments are self, the canvas to plot the figure on and the
@@ -52,16 +55,17 @@ def plot_figure(self, canvas, X, Y, filename=', xlim=None, linewidth = 2, title=
     """
     if y_axis == 'left':
         if x_axis == 'bottom':
-            canvas.ax.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
+            canvas.ax.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
         elif x_axis == 'top':
-            canvas.top_left_axis.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
+            canvas.top_left_axis.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
     elif y_axis == 'right':
         if x_axis == 'bottom':
-            canvas.right_axis.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
+            canvas.right_axis.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
         elif x_axis == 'top':
-            canvas.top_right_axis.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
-            canvas.top_right_axis.set_yscale(self.plot_settings.right_scale)          
+            canvas.top_right_axis.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.top_right_axis.set_yscale(self.plot_settings.right_scale)
     set_legend(self, canvas)
+
 
 def set_legend(self, canvas):
     """
@@ -75,19 +79,11 @@ def set_legend(self, canvas):
         lines4, labels4 = canvas.top_right_axis.get_legend_handles_labels()
         canvas.top_right_axis.legend(lines + lines2 + lines3 + lines4, labels + labels2 + labels3 + labels4, loc=0, frameon=True)
 
-def set_canvas_limits_axis(self, canvas, limits = {'xmin':None, 'xmax':None, 'ymin':None, 'ymax':None}):
+
+def set_canvas_limits_axis(self, canvas, limits={'xmin': None, 'xmax': None, 'ymin': None, 'ymax': None}):
     """
     Set the canvas limits for each axis that is present
     """
-    min_left = None
-    max_left = None
-    min_top = None
-    max_top = None
-    min_right = None
-    max_right = None
-    min_bottom = None
-    max_bottom = None
-
     used_axes, item_list = get_used_axes(self)
 
     for axis in used_axes:
@@ -112,25 +108,26 @@ def set_canvas_limits_axis(self, canvas, limits = {'xmin':None, 'xmax':None, 'ym
                 bottom_items.append(key)
             bottom_limits = find_limits(self, axis, canvas, bottom_items)
     if used_axes['left'] and used_axes['bottom']:
-        set_canvas_limits(self, left_limits, self.canvas.ax, axis_type = 'Y')
-        set_canvas_limits(self, bottom_limits, self.canvas.ax, axis_type = 'X')
+        set_canvas_limits(self, left_limits, self.canvas.ax, axis_type='Y')
+        set_canvas_limits(self, bottom_limits, self.canvas.ax, axis_type='X')
     if used_axes['left'] and used_axes['top']:
-        set_canvas_limits(self, left_limits, self.canvas.top_left_axis, axis_type = 'Y')
-        set_canvas_limits(self, top_limits, self.canvas.top_left_axis, axis_type = 'X')
+        set_canvas_limits(self, left_limits, self.canvas.top_left_axis, axis_type='Y')
+        set_canvas_limits(self, top_limits, self.canvas.top_left_axis, axis_type='X')
     if used_axes['right'] and used_axes['bottom']:
-        set_canvas_limits(self, right_limits, self.canvas.right_axis, axis_type = 'Y')
-        set_canvas_limits(self, bottom_limits, self.canvas.right_axis, axis_type = 'X')
+        set_canvas_limits(self, right_limits, self.canvas.right_axis, axis_type='Y')
+        set_canvas_limits(self, bottom_limits, self.canvas.right_axis, axis_type='X')
     if used_axes['right'] and used_axes['top']:
-        set_canvas_limits(self, right_limits, self.canvas.top_right_axis, axis_type = 'Y')
-        set_canvas_limits(self, top_limits, self.canvas.top_right_axis, axis_type = 'X')
+        set_canvas_limits(self, right_limits, self.canvas.top_right_axis, axis_type='Y')
+        set_canvas_limits(self, top_limits, self.canvas.top_right_axis, axis_type='X')
+
 
 def get_used_axes(self):
-    used_axis = dict()
+    used_axis = {}
     used_axis['left'] = False
     used_axis['right'] = False
     used_axis['top'] = False
     used_axis['bottom'] = False
-    item_list = dict()
+    item_list = {}
     left_items = []
     right_items = []
     top_items = []
@@ -155,19 +152,20 @@ def get_used_axes(self):
     item_list['bottom'] = bottom_items
     return used_axis, item_list
 
-def set_canvas_limits(self, graph_limits, axis, axis_type, limits = {'xmin':None, 'xmax':None, 'ymin':None, 'ymax':None}):
+
+def set_canvas_limits(self, graph_limits, axis, axis_type, limits={'xmin': None, 'xmax': None, 'ymin': None, 'ymax': None}):
     """
     Set an calculate the canvas limits for a given axis.
     """
-    #Update graph limits with limits that were given as argument
+    # Update graph limits with limits that were given as argument
     for key, item in limits.items():
         if item is not None:
             graph_limits[key] = item
     x_span = (graph_limits['xmax'] - graph_limits['xmin'])
     y_span = (graph_limits['ymax'] - graph_limits['ymin'])
     if axis.get_xscale() == 'linear':
-        graph_limits['xmin'] -= 0.015*x_span
-        graph_limits['xmax'] += 0.015*x_span
+        graph_limits['xmin'] -= 0.015 * x_span
+        graph_limits['xmax'] += 0.015 * x_span
     if axis.get_yscale() == 'linear':
         if y_span != 0:
             if graph_limits['ymin'] > 0:
@@ -176,8 +174,8 @@ def set_canvas_limits(self, graph_limits, axis, axis_type, limits = {'xmin':None
                 graph_limits['ymin'] *= 1.05
             graph_limits['ymax'] *= 1.05
         else:
-            graph_limits['ymax'] +=  abs(graph_limits['ymax']*0.05)
-            graph_limits['ymin'] -=  abs(graph_limits['ymin']*0.05)
+            graph_limits['ymax'] += abs(graph_limits['ymax'] * 0.05)
+            graph_limits['ymin'] -= abs(graph_limits['ymin'] * 0.05)
     else:
         graph_limits['ymin'] *= 0.5
         graph_limits['ymax'] *= 2
@@ -188,7 +186,8 @@ def set_canvas_limits(self, graph_limits, axis, axis_type, limits = {'xmin':None
             axis.set_ylim(graph_limits['ymin'], graph_limits['ymax'])
     except ValueError:
         print('Could not set limits, one of the values was probably infinite')
-        
+
+
 def find_limits(self, axis, canvas, datadict):
     """
     Find the limits that are to be used for the axes.
@@ -200,13 +199,13 @@ def find_limits(self, axis, canvas, datadict):
 
     for key in datadict:
         item = self.datadict[key]
-        #Check the limits of each item, as long as it exists and it has the same axes as the one we're adjusting right now
+        # Check the limits of each item, as long as it exists and it has the same axes as the one we're adjusting right now
         if item is not None and len(item.xdata) > 0:
-            #Nonzero ydata is needed for logs
+            # Nonzero ydata is needed for logs
             nonzero_ydata = list(filter(lambda x: (x != 0), item.ydata))
             xmin_item = min(item.xdata)
             xmax_item = max(item.xdata)
-            
+
             if axis == 'log' and len(nonzero_ydata) > 0:
                 ymin_item = min(nonzero_ydata)
             else:
@@ -229,19 +228,18 @@ def find_limits(self, axis, canvas, datadict):
                 ymin_all = ymin_item
             if ymax_item > ymax_all:
                 ymax_all = ymax_item
-    return {'xmin':xmin_all, 'xmax':xmax_all, 'ymin':ymin_all, 'ymax':ymax_all}
+    return {'xmin': xmin_all, 'xmax': xmax_all, 'ymin': ymin_all, 'ymax': ymax_all}
 
 
-def reload_plot(self, from_dictionary = True):
+def reload_plot(self, from_dictionary=True):
     """
     Completely reload the plot of the graph
     """
-    win = self.main_window
     graphs.load_empty(self)
     if len(self.datadict) > 0:
         hide_unused_axes(self, self.canvas)
         graphs.open_selection_from_dict(self)
-        if (not self.highlight is None):
+        if self.highlight is not None:
             self.highlight.set_visible(False)
             self.highlight.set_active(False)
             self.highlight = None
@@ -250,7 +248,7 @@ def reload_plot(self, from_dictionary = True):
     self.canvas.grab_focus()
 
 
-def refresh_plot(self, canvas = None, from_dictionary = True, set_limits = True):
+def refresh_plot(self, canvas=None, from_dictionary=True, set_limits=True):
     """
     Refresh the graph without completely reloading it.
     """
@@ -272,12 +270,11 @@ def refresh_plot(self, canvas = None, from_dictionary = True, set_limits = True)
     self.canvas.draw()
 
 
-
 def hide_unused_axes(self, canvas):
     """
     Hide axes that are not in use, to avoid unnecessary ticks in the plots.
     """
-    #Double check the code here, seems to work but this is too messy
+    # Double check the code here, seems to work but this is too messy
     for axis in [canvas.ax, canvas.right_axis, canvas.top_left_axis, canvas.top_right_axis]:
         axis.get_xaxis().set_visible(True)
         axis.get_yaxis().set_visible(True)
@@ -311,7 +308,7 @@ def hide_unused_axes(self, canvas):
     canvas.right_axis.get_xaxis().set_visible(False)
     canvas.top_right_axis.get_yaxis().set_visible(False)
     canvas.top_left_axis.get_yaxis().set_visible(False)
-    
+
 
 def change_left_yscale(action, target, self):
     if target.get_string() == 'log':
@@ -324,6 +321,7 @@ def change_left_yscale(action, target, self):
     action.change_state(target)
     set_canvas_limits_axis(self, self.canvas)
     self.canvas.draw()
+
 
 def change_right_yscale(action, target, self):
     if target.get_string() == 'log':
@@ -339,6 +337,7 @@ def change_right_yscale(action, target, self):
     set_canvas_limits_axis(self, self.canvas)
     self.canvas.draw()
 
+
 def change_top_xscale(action, target, self):
     if target.get_string() == 'log':
         self.canvas.top_left_axis.set_xscale('log')
@@ -352,6 +351,7 @@ def change_top_xscale(action, target, self):
     action.change_state(target)
     set_canvas_limits_axis(self, self.canvas)
     self.canvas.draw()
+
 
 def change_bottom_xscale(action, target, self):
     if target.get_string() == 'log':
@@ -367,6 +367,7 @@ def change_bottom_xscale(action, target, self):
     set_canvas_limits_axis(self, self.canvas)
     self.canvas.draw()
 
+
 def get_next_color(self):
     """
     Get the color that is to be used for the next data set
@@ -377,15 +378,16 @@ def get_next_color(self):
     color_length = len(color_list)
     if len(item_rows) >= color_length:
         item_rows_list = list(item_rows.items())
-        item_rows_list = item_rows_list[-color_length+1:]
+        item_rows_list = item_rows_list[- color_length + 1:]
         item_rows = dict(item_rows_list)
     for key, item in item_rows.items():
         used_colors.append(item.color_picker.color)
     used_colors = [colors.to_rgb(color) for color in used_colors]
-    
+
     for color in color_list:
         if color not in used_colors:
             return color
+
 
 def load_fonts(self):
     """
@@ -395,8 +397,9 @@ def load_fonts(self):
     for font in font_list:
         try:
             matplotlib.font_manager.fontManager.addfont(font)
-        except:
+        except Exception:
             print(f'Could not load {font}')
+
 
 class PlotSettings:
     """
@@ -428,8 +431,7 @@ class PlotSettings:
         self.tick_left = parent.preferences.config['plot_tick_left']
         self.tick_right = parent.preferences.config['plot_tick_right']
         self.legend = parent.preferences.config['plot_legend']
-        if Adw.StyleManager.get_default().get_dark(): 
+        if Adw.StyleManager.get_default().get_dark():
             self.plot_style = parent.preferences.config['plot_style_dark']
         else:
             self.plot_style = parent.preferences.config['plot_style_light']
-

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -21,7 +21,10 @@ def define_highlight(self, span=None):
         lambda x, y: on_highlight_define(self),
         "horizontal",
         useblit=True,
-        props={"facecolor": (color.red, color.green, color.blue, 0.3), "edgecolor": (color.red, color.green, color.blue, 1), "linewidth": 1},
+        props={
+            "facecolor": (color.red, color.green, color.blue, 0.3),
+            "edgecolor": (color.red, color.green, color.blue, 1),
+            "linewidth": 1},
         handle_props={"linewidth": 0},
         interactive=True,
         drag_from_anywhere=True)
@@ -32,8 +35,8 @@ def define_highlight(self, span=None):
 def on_highlight_define(self):
     """
     This ensures that the span selector doesn"t go out of range
-    There are some obscure cases where this otherwise happens, and the selection
-    tool becomes unusable.
+    There are some obscure cases where this otherwise happens, and the
+    selection tool becomes unusable.
     """
     xmin = min(self.canvas.top_right_axis.get_xlim())
     xmax = max(self.canvas.top_right_axis.get_xlim())
@@ -46,23 +49,35 @@ def on_highlight_define(self):
     self.highlight.extents = (extend_min, extend_max)
 
 
-def plot_figure(self, canvas, x_data, y_data, filename="", linewidth=2, marker=None, linestyle="solid",
-                color=None, marker_size=10, y_axis="left", x_axis="bottom"):
+def plot_figure(self, canvas, x_data, y_data, filename="", linewidth=2,
+                marker=None, linestyle="solid", color=None, marker_size=10,
+                y_axis="left", x_axis="bottom"):
     """
     Plot the figure on the graph
-    Necessary input arguments are self, the canvas to plot the figure on and the
-    X and Y data
+    Necessary input arguments are self, the canvas to plot the figure on and
+    the X and Y data
     """
     if y_axis == "left":
         if x_axis == "bottom":
-            canvas.ax.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.ax.plot(x_data, y_data, linewidth=linewidth, label=filename,
+                           linestyle=linestyle, marker=marker, color=color,
+                           markersize=marker_size)
         elif x_axis == "top":
-            canvas.top_left_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.top_left_axis.plot(x_data, y_data, linewidth=linewidth,
+                                      label=filename, linestyle=linestyle,
+                                      marker=marker, color=color,
+                                      markersize=marker_size)
     elif y_axis == "right":
         if x_axis == "bottom":
-            canvas.right_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.right_axis.plot(x_data, y_data, linewidth=linewidth,
+                                   label=filename, linestyle=linestyle,
+                                   marker=marker, color=color,
+                                   markersize=marker_size)
         elif x_axis == "top":
-            canvas.top_right_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.top_right_axis.plot(x_data, y_data, linewidth=linewidth,
+                                       label=filename, linestyle=linestyle,
+                                       marker=marker, color=color,
+                                       markersize=marker_size)
             canvas.top_right_axis.set_yscale(self.plot_settings.right_scale)
     set_legend(self, canvas)
 
@@ -75,7 +90,9 @@ def set_legend(self, canvas):
         lines2, labels2 = canvas.right_axis.get_legend_handles_labels()
         lines3, labels3 = canvas.top_left_axis.get_legend_handles_labels()
         lines4, labels4 = canvas.top_right_axis.get_legend_handles_labels()
-        canvas.top_right_axis.legend(lines + lines2 + lines3 + lines4, labels + labels2 + labels3 + labels4, loc=0, frameon=True)
+        canvas.top_right_axis.legend(
+            lines + lines2 + lines3 + lines4,
+            labels + labels2 + labels3 + labels4, loc=0, frameon=True)
 
 
 def set_canvas_limits_axis(self):
@@ -87,12 +104,14 @@ def set_canvas_limits_axis(self):
             left_items = []
             for key in item_list["left"]:
                 left_items.append(key)
-            left_limits = find_limits(self, self.canvas.ax.get_yscale(), left_items)
+            left_limits = find_limits(
+                self, self.canvas.ax.get_yscale(), left_items)
         if axis == "right":
             right_items = []
             for key in item_list["right"]:
                 right_items.append(key)
-            right_limits = find_limits(self, self.canvas.right_axis.get_yscale(), right_items)
+            right_limits = find_limits(
+                self, self.canvas.right_axis.get_yscale(), right_items)
         if axis == "top":
             top_items = []
             for key in item_list["top"]:
@@ -107,14 +126,17 @@ def set_canvas_limits_axis(self):
         set_canvas_limits(left_limits, self.canvas.ax, axis_type="Y")
         set_canvas_limits(bottom_limits, self.canvas.ax, axis_type="X")
     if used_axes["left"] and used_axes["top"]:
-        set_canvas_limits(left_limits, self.canvas.top_left_axis, axis_type="Y")
+        set_canvas_limits(
+            left_limits, self.canvas.top_left_axis, axis_type="Y")
         set_canvas_limits(top_limits, self.canvas.top_left_axis, axis_type="X")
     if used_axes["right"] and used_axes["bottom"]:
         set_canvas_limits(right_limits, self.canvas.right_axis, axis_type="Y")
         set_canvas_limits(bottom_limits, self.canvas.right_axis, axis_type="X")
     if used_axes["right"] and used_axes["top"]:
-        set_canvas_limits(right_limits, self.canvas.top_right_axis, axis_type="Y")
-        set_canvas_limits(top_limits, self.canvas.top_right_axis, axis_type="X")
+        set_canvas_limits(
+            right_limits, self.canvas.top_right_axis, axis_type="Y")
+        set_canvas_limits(
+            top_limits, self.canvas.top_right_axis, axis_type="X")
 
 
 def get_used_axes(self):
@@ -149,7 +171,9 @@ def get_used_axes(self):
     return used_axis, item_list
 
 
-def set_canvas_limits(graph_limits, axis, axis_type, limits={"xmin": None, "xmax": None, "ymin": None, "ymax": None}):
+def set_canvas_limits(graph_limits, axis, axis_type,
+                      limits={"xmin": None, "xmax": None,
+                              "ymin": None, "ymax": None}):
     """Set an calculate the canvas limits for a given axis."""
     # Update graph limits with limits that were given as argument
     for key, item in limits.items():
@@ -191,7 +215,8 @@ def find_limits(self, axis, datadict):
 
     for key in datadict:
         item = self.datadict[key]
-        # Check the limits of each item, as long as it exists and it has the same axes as the one we"re adjusting right now
+        # Check the limits of each item, as long as it exists and it has the
+        # same axes as the one we"re adjusting right now
         if item is not None and len(item.xdata) > 0:
             # Nonzero ydata is needed for logs
             nonzero_ydata = list(filter(lambda x: (x != 0), item.ydata))
@@ -220,7 +245,11 @@ def find_limits(self, axis, datadict):
                 ymin_all = ymin_item
             if ymax_item > ymax_all:
                 ymax_all = ymax_item
-    return {"xmin": xmin_all, "xmax": xmax_all, "ymin": ymin_all, "ymax": ymax_all}
+    return {
+        "xmin": xmin_all,
+        "xmax": xmax_all,
+        "ymin": ymin_all,
+        "ymax": ymax_all}
 
 
 def reload_plot(self):
@@ -259,9 +288,13 @@ def refresh_plot(self, canvas=None, set_limits=True):
 
 
 def hide_unused_axes(self, canvas):
-    """Hide axes that are not in use, to avoid unnecessary ticks in the plots."""
+    """
+    Hide axes that are not in use,
+    to avoid unnecessary ticks in the plots.
+    """
     # Double check the code here, seems to work but this is too messy
-    for axis in [canvas.ax, canvas.right_axis, canvas.top_left_axis, canvas.top_right_axis]:
+    for axis in [canvas.ax, canvas.right_axis,
+                 canvas.top_left_axis, canvas.top_right_axis]:
         axis.get_xaxis().set_visible(True)
         axis.get_yaxis().set_visible(True)
     left = False
@@ -376,7 +409,8 @@ def get_next_color(self):
 
 def load_fonts():
     """Load system fonts that are installed on the system"""
-    font_list = matplotlib.font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
+    font_list = matplotlib.font_manager.findSystemFonts(
+        fontpaths=None, fontext="ttf")
     for font in font_list:
         try:
             matplotlib.font_manager.fontManager.addfont(font)
@@ -405,10 +439,14 @@ class PlotSettings:
         self.font_size = parent.preferences.config["plot_font_size"]
         self.font_style = parent.preferences.config["plot_font_style"]
         self.tick_direction = parent.preferences.config["plot_tick_direction"]
-        self.major_tick_length = parent.preferences.config["plot_major_tick_length"]
-        self.minor_tick_length = parent.preferences.config["plot_minor_tick_length"]
-        self.major_tick_width = parent.preferences.config["plot_major_tick_width"]
-        self.minor_tick_width = parent.preferences.config["plot_minor_tick_width"]
+        self.major_tick_length = parent.preferences.config[
+            "plot_major_tick_length"]
+        self.minor_tick_length = parent.preferences.config[
+            "plot_minor_tick_length"]
+        self.major_tick_width = parent.preferences.config[
+            "plot_major_tick_width"]
+        self.minor_tick_width = parent.preferences.config[
+            "plot_minor_tick_width"]
         self.tick_top = parent.preferences.config["plot_tick_top"]
         self.tick_bottom = parent.preferences.config["plot_tick_bottom"]
         self.tick_left = parent.preferences.config["plot_tick_left"]

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -21,8 +21,8 @@ def define_highlight(self, span=None):
         lambda x, y: on_highlight_define(self),
         'horizontal',
         useblit=True,
-        props={(color.red, color.green, color.blue, 0.3), (color.red, color.green, color.blue, 1), 1},
-        handle_props={0},
+        props={'facecolor': (color.red, color.green, color.blue, 0.3), 'edgecolor': (color.red, color.green, color.blue, 1), 'linewidth': 1},
+        handle_props={'linewidth': 0},
         interactive=True,
         drag_from_anywhere=True)
     if span is not None:

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -18,7 +18,7 @@ def define_highlight(self, span=None):
     self.highlight = SpanSelector(
         self.canvas.top_right_axis,
         lambda x, y: on_highlight_define(self),
-        "horizontal",
+        'horizontal',
         useblit=True,
         props=dict(facecolor = (color.red, color.green, color.blue, 0.3), edgecolor = (color.red, color.green, color.blue, 1), linewidth = 1),
         handle_props=dict(linewidth=0),
@@ -43,22 +43,22 @@ def on_highlight_define(self):
         extend_max = xmax  
     self.highlight.extents = (extend_min, extend_max)
 
-def plot_figure(self, canvas, X, Y, filename="", xlim=None, linewidth = 2, title="", scale="log",marker=None, linestyle="solid",
-                     revert = False, color = None, marker_size = 10, y_axis = "left", x_axis = "bottom"):
+def plot_figure(self, canvas, X, Y, filename=', xlim=None, linewidth = 2, title=', scale='log',marker=None, linestyle='solid',
+                     revert = False, color = None, marker_size = 10, y_axis = 'left', x_axis = 'bottom'):
     """
     Plot the figure on the graph
     Necessary input arguments are self, the canvas to plot the figure on and the
     X and Y data
     """
-    if y_axis == "left":
-        if x_axis == "bottom":
+    if y_axis == 'left':
+        if x_axis == 'bottom':
             canvas.ax.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
-        elif x_axis == "top":
+        elif x_axis == 'top':
             canvas.top_left_axis.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
-    elif y_axis == "right":
-        if x_axis == "bottom":
+    elif y_axis == 'right':
+        if x_axis == 'bottom':
             canvas.right_axis.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
-        elif x_axis == "top":
+        elif x_axis == 'top':
             canvas.top_right_axis.plot(X, Y, linewidth = linewidth ,label=filename, linestyle=linestyle, marker=marker, color = color, markersize=marker_size)
             canvas.top_right_axis.set_yscale(self.plot_settings.right_scale)          
     set_legend(self, canvas)
@@ -75,7 +75,7 @@ def set_legend(self, canvas):
         lines4, labels4 = canvas.top_right_axis.get_legend_handles_labels()
         canvas.top_right_axis.legend(lines + lines2 + lines3 + lines4, labels + labels2 + labels3 + labels4, loc=0, frameon=True)
 
-def set_canvas_limits_axis(self, canvas, limits = {"xmin":None, "xmax":None, "ymin":None, "ymax":None}):
+def set_canvas_limits_axis(self, canvas, limits = {'xmin':None, 'xmax':None, 'ymin':None, 'ymax':None}):
     """
     Set the canvas limits for each axis that is present
     """
@@ -91,45 +91,45 @@ def set_canvas_limits_axis(self, canvas, limits = {"xmin":None, "xmax":None, "ym
     used_axes, item_list = get_used_axes(self)
 
     for axis in used_axes:
-        if axis == "left":
+        if axis == 'left':
             left_items = []
-            for key in item_list["left"]:
+            for key in item_list['left']:
                 left_items.append(key)
             left_limits = find_limits(self, self.canvas.ax.get_yscale(), canvas, left_items)
-        if axis == "right":
+        if axis == 'right':
             right_items = []
-            for key in item_list["right"]:
+            for key in item_list['right']:
                 right_items.append(key)
             right_limits = find_limits(self, self.canvas.right_axis.get_yscale(), canvas, right_items)
-        if axis == "top":
+        if axis == 'top':
             top_items = []
-            for key in item_list["top"]:
+            for key in item_list['top']:
                 top_items.append(key)
             top_limits = find_limits(self, axis, canvas, top_items)
-        if axis == "bottom":
+        if axis == 'bottom':
             bottom_items = []
-            for key in item_list["bottom"]:
+            for key in item_list['bottom']:
                 bottom_items.append(key)
             bottom_limits = find_limits(self, axis, canvas, bottom_items)
-    if used_axes["left"] and used_axes["bottom"]:
-        set_canvas_limits(self, left_limits, self.canvas.ax, axis_type = "Y")
-        set_canvas_limits(self, bottom_limits, self.canvas.ax, axis_type = "X")
-    if used_axes["left"] and used_axes["top"]:
-        set_canvas_limits(self, left_limits, self.canvas.top_left_axis, axis_type = "Y")
-        set_canvas_limits(self, top_limits, self.canvas.top_left_axis, axis_type = "X")
-    if used_axes["right"] and used_axes["bottom"]:
-        set_canvas_limits(self, right_limits, self.canvas.right_axis, axis_type = "Y")
-        set_canvas_limits(self, bottom_limits, self.canvas.right_axis, axis_type = "X")
-    if used_axes["right"] and used_axes["top"]:
-        set_canvas_limits(self, right_limits, self.canvas.top_right_axis, axis_type = "Y")
-        set_canvas_limits(self, top_limits, self.canvas.top_right_axis, axis_type = "X")
+    if used_axes['left'] and used_axes['bottom']:
+        set_canvas_limits(self, left_limits, self.canvas.ax, axis_type = 'Y')
+        set_canvas_limits(self, bottom_limits, self.canvas.ax, axis_type = 'X')
+    if used_axes['left'] and used_axes['top']:
+        set_canvas_limits(self, left_limits, self.canvas.top_left_axis, axis_type = 'Y')
+        set_canvas_limits(self, top_limits, self.canvas.top_left_axis, axis_type = 'X')
+    if used_axes['right'] and used_axes['bottom']:
+        set_canvas_limits(self, right_limits, self.canvas.right_axis, axis_type = 'Y')
+        set_canvas_limits(self, bottom_limits, self.canvas.right_axis, axis_type = 'X')
+    if used_axes['right'] and used_axes['top']:
+        set_canvas_limits(self, right_limits, self.canvas.top_right_axis, axis_type = 'Y')
+        set_canvas_limits(self, top_limits, self.canvas.top_right_axis, axis_type = 'X')
 
 def get_used_axes(self):
     used_axis = dict()
-    used_axis["left"] = False
-    used_axis["right"] = False
-    used_axis["top"] = False
-    used_axis["bottom"] = False
+    used_axis['left'] = False
+    used_axis['right'] = False
+    used_axis['top'] = False
+    used_axis['bottom'] = False
     item_list = dict()
     left_items = []
     right_items = []
@@ -137,25 +137,25 @@ def get_used_axes(self):
     bottom_items = []
 
     for key, item in self.datadict.items():
-        if item.plot_Y_position == "left":
-            used_axis["left"] = True
+        if item.plot_Y_position == 'left':
+            used_axis['left'] = True
             left_items.append(key)
-        if item.plot_Y_position == "right":
-            used_axis["right"] = True
+        if item.plot_Y_position == 'right':
+            used_axis['right'] = True
             right_items.append(key)
-        if item.plot_X_position == "top":
-            used_axis["top"] = True
+        if item.plot_X_position == 'top':
+            used_axis['top'] = True
             top_items.append(key)
-        if item.plot_X_position == "bottom":
-            used_axis["bottom"] = True
+        if item.plot_X_position == 'bottom':
+            used_axis['bottom'] = True
             bottom_items.append(key)
-    item_list["left"] = left_items
-    item_list["right"] = right_items
-    item_list["top"] = top_items
-    item_list["bottom"] = bottom_items
+    item_list['left'] = left_items
+    item_list['right'] = right_items
+    item_list['top'] = top_items
+    item_list['bottom'] = bottom_items
     return used_axis, item_list
 
-def set_canvas_limits(self, graph_limits, axis, axis_type, limits = {"xmin":None, "xmax":None, "ymin":None, "ymax":None}):
+def set_canvas_limits(self, graph_limits, axis, axis_type, limits = {'xmin':None, 'xmax':None, 'ymin':None, 'ymax':None}):
     """
     Set an calculate the canvas limits for a given axis.
     """
@@ -163,31 +163,31 @@ def set_canvas_limits(self, graph_limits, axis, axis_type, limits = {"xmin":None
     for key, item in limits.items():
         if item is not None:
             graph_limits[key] = item
-    x_span = (graph_limits["xmax"] - graph_limits["xmin"])
-    y_span = (graph_limits["ymax"] - graph_limits["ymin"])
-    if axis.get_xscale() == "linear":
-        graph_limits["xmin"] -= 0.015*x_span
-        graph_limits["xmax"] += 0.015*x_span
-    if axis.get_yscale() == "linear":
+    x_span = (graph_limits['xmax'] - graph_limits['xmin'])
+    y_span = (graph_limits['ymax'] - graph_limits['ymin'])
+    if axis.get_xscale() == 'linear':
+        graph_limits['xmin'] -= 0.015*x_span
+        graph_limits['xmax'] += 0.015*x_span
+    if axis.get_yscale() == 'linear':
         if y_span != 0:
-            if graph_limits["ymin"] > 0:
-                graph_limits["ymin"] *= 0.95
+            if graph_limits['ymin'] > 0:
+                graph_limits['ymin'] *= 0.95
             else:
-                graph_limits["ymin"] *= 1.05
-            graph_limits["ymax"] *= 1.05        
+                graph_limits['ymin'] *= 1.05
+            graph_limits['ymax'] *= 1.05
         else:
-            graph_limits["ymax"] +=  abs(graph_limits["ymax"]*0.05)            
-            graph_limits["ymin"] -=  abs(graph_limits["ymin"]*0.05)
+            graph_limits['ymax'] +=  abs(graph_limits['ymax']*0.05)
+            graph_limits['ymin'] -=  abs(graph_limits['ymin']*0.05)
     else:
-        graph_limits["ymin"] *= 0.5
-        graph_limits["ymax"] *= 2
+        graph_limits['ymin'] *= 0.5
+        graph_limits['ymax'] *= 2
     try:
-        if axis_type == "X":
-            axis.set_xlim(graph_limits["xmin"], graph_limits["xmax"])
-        if axis_type == "Y":
-            axis.set_ylim(graph_limits["ymin"], graph_limits["ymax"])
+        if axis_type == 'X':
+            axis.set_xlim(graph_limits['xmin'], graph_limits['xmax'])
+        if axis_type == 'Y':
+            axis.set_ylim(graph_limits['ymin'], graph_limits['ymax'])
     except ValueError:
-        print("Could not set limits, one of the values was probably infinite")
+        print('Could not set limits, one of the values was probably infinite')
         
 def find_limits(self, axis, canvas, datadict):
     """
@@ -207,7 +207,7 @@ def find_limits(self, axis, canvas, datadict):
             xmin_item = min(item.xdata)
             xmax_item = max(item.xdata)
             
-            if axis == "log" and len(nonzero_ydata) > 0:
+            if axis == 'log' and len(nonzero_ydata) > 0:
                 ymin_item = min(nonzero_ydata)
             else:
                 ymin_item = min(item.ydata)
@@ -229,7 +229,7 @@ def find_limits(self, axis, canvas, datadict):
                 ymin_all = ymin_item
             if ymax_item > ymax_all:
                 ymax_all = ymax_item
-    return {"xmin":xmin_all, "xmax":xmax_all, "ymin":ymin_all, "ymax":ymax_all}
+    return {'xmin':xmin_all, 'xmax':xmax_all, 'ymin':ymin_all, 'ymax':ymax_all}
 
 
 def reload_plot(self, from_dictionary = True):
@@ -286,13 +286,13 @@ def hide_unused_axes(self, canvas):
     top = False
     bottom = False
     for key, item in self.datadict.items():
-        if item.plot_Y_position == "left":
+        if item.plot_Y_position == 'left':
             left = True
-        if item.plot_Y_position == "right":
+        if item.plot_Y_position == 'right':
             right = True
-        if item.plot_X_position == "top":
+        if item.plot_X_position == 'top':
             top = True
-        if item.plot_X_position == "bottom":
+        if item.plot_X_position == 'bottom':
             bottom = True
     if not left:
         canvas.top_left_axis.get_yaxis().set_visible(False)
@@ -316,10 +316,10 @@ def hide_unused_axes(self, canvas):
 def change_left_yscale(action, target, self):
     if target.get_string() == 'log':
         self.canvas.ax.set_yscale('log')
-        self.plot_settings.yscale = "log"
+        self.plot_settings.yscale = 'log'
     else:
         self.canvas.ax.set_yscale('linear')
-        self.plot_settings.yscale = "linear"
+        self.plot_settings.yscale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self, self.canvas)
@@ -329,11 +329,11 @@ def change_right_yscale(action, target, self):
     if target.get_string() == 'log':
         self.canvas.top_right_axis.set_yscale('log')
         self.canvas.right_axis.set_yscale('log')
-        self.plot_settings.right_scale = "log"
+        self.plot_settings.right_scale = 'log'
     else:
         self.canvas.top_right_axis.set_yscale('linear')
         self.canvas.right_axis.set_yscale('linear')
-        self.plot_settings.right_scale = "linear"
+        self.plot_settings.right_scale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self, self.canvas)
@@ -343,11 +343,11 @@ def change_top_xscale(action, target, self):
     if target.get_string() == 'log':
         self.canvas.top_left_axis.set_xscale('log')
         self.canvas.top_right_axis.set_xscale('log')
-        self.plot_settings.top_scale = "log"
+        self.plot_settings.top_scale = 'log'
     else:
         self.canvas.top_left_axis.set_xscale('linear')
         self.canvas.top_right_axis.set_xscale('linear')
-        self.plot_settings.top_scale = "linear"
+        self.plot_settings.top_scale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self, self.canvas)
@@ -357,11 +357,11 @@ def change_bottom_xscale(action, target, self):
     if target.get_string() == 'log':
         self.canvas.ax.set_xscale('log')
         self.canvas.right_axis.set_xscale('log')
-        self.plot_settings.xscale = "log"
+        self.plot_settings.xscale = 'log'
     else:
         self.canvas.ax.set_xscale('linear')
         self.canvas.right_axis.set_xscale('linear')
-        self.plot_settings.xscale = "linear"
+        self.plot_settings.xscale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
     set_canvas_limits_axis(self, self.canvas)
@@ -396,7 +396,7 @@ def load_fonts(self):
         try:
             matplotlib.font_manager.fontManager.addfont(font)
         except:
-            print(f"Could not load {font}")
+            print(f'Could not load {font}')
 
 class PlotSettings:
     """
@@ -404,32 +404,32 @@ class PlotSettings:
     retreived from the config file through preferences.
     """
     def __init__(self, parent):
-        self.font_string = parent.preferences.config["plot_font_string"]
-        self.xlabel = parent.preferences.config["plot_X_label"]
-        self.right_label = parent.preferences.config["plot_right_label"]
-        self.top_label = parent.preferences.config["plot_top_label"]
-        self.ylabel = parent.preferences.config["plot_Y_label"]
-        self.xscale = parent.preferences.config["plot_X_scale"]
-        self.yscale = parent.preferences.config["plot_Y_scale"]
-        self.right_scale = parent.preferences.config["plot_right_scale"]
-        self.top_scale = parent.preferences.config["plot_top_scale"]
-        self.title = parent.preferences.config["plot_title"]
-        self.font_weight = parent.preferences.config["plot_font_weight"]
-        self.font_family = parent.preferences.config["plot_font_family"]
-        self.font_size = parent.preferences.config["plot_font_size"]
-        self.font_style = parent.preferences.config["plot_font_style"]
-        self.tick_direction = parent.preferences.config["plot_tick_direction"]
-        self.major_tick_length = parent.preferences.config["plot_major_tick_length"]
-        self.minor_tick_length = parent.preferences.config["plot_minor_tick_length"]
-        self.major_tick_width = parent.preferences.config["plot_major_tick_width"]
-        self.minor_tick_width = parent.preferences.config["plot_minor_tick_width"]
-        self.tick_top = parent.preferences.config["plot_tick_top"]
-        self.tick_bottom = parent.preferences.config["plot_tick_bottom"]
-        self.tick_left = parent.preferences.config["plot_tick_left"]
-        self.tick_right = parent.preferences.config["plot_tick_right"]
-        self.legend = parent.preferences.config["plot_legend"]
+        self.font_string = parent.preferences.config['plot_font_string']
+        self.xlabel = parent.preferences.config['plot_X_label']
+        self.right_label = parent.preferences.config['plot_right_label']
+        self.top_label = parent.preferences.config['plot_top_label']
+        self.ylabel = parent.preferences.config['plot_Y_label']
+        self.xscale = parent.preferences.config['plot_X_scale']
+        self.yscale = parent.preferences.config['plot_Y_scale']
+        self.right_scale = parent.preferences.config['plot_right_scale']
+        self.top_scale = parent.preferences.config['plot_top_scale']
+        self.title = parent.preferences.config['plot_title']
+        self.font_weight = parent.preferences.config['plot_font_weight']
+        self.font_family = parent.preferences.config['plot_font_family']
+        self.font_size = parent.preferences.config['plot_font_size']
+        self.font_style = parent.preferences.config['plot_font_style']
+        self.tick_direction = parent.preferences.config['plot_tick_direction']
+        self.major_tick_length = parent.preferences.config['plot_major_tick_length']
+        self.minor_tick_length = parent.preferences.config['plot_minor_tick_length']
+        self.major_tick_width = parent.preferences.config['plot_major_tick_width']
+        self.minor_tick_width = parent.preferences.config['plot_minor_tick_width']
+        self.tick_top = parent.preferences.config['plot_tick_top']
+        self.tick_bottom = parent.preferences.config['plot_tick_bottom']
+        self.tick_left = parent.preferences.config['plot_tick_left']
+        self.tick_right = parent.preferences.config['plot_tick_right']
+        self.legend = parent.preferences.config['plot_legend']
         if Adw.StyleManager.get_default().get_dark(): 
-            self.plot_style = parent.preferences.config["plot_style_dark"]
+            self.plot_style = parent.preferences.config['plot_style_dark']
         else:
-            self.plot_style = parent.preferences.config["plot_style_light"]
+            self.plot_style = parent.preferences.config['plot_style_light']
 

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -46,8 +46,8 @@ def on_highlight_define(self):
     self.highlight.extents = (extend_min, extend_max)
 
 
-def plot_figure(self, canvas, x_data, y_data, filename='', xlim=None, linewidth=2, title='', scale='log', marker=None, linestyle='solid',
-                revert=False, color=None, marker_size=10, y_axis='left', x_axis='bottom'):
+def plot_figure(self, canvas, x_data, y_data, filename='', linewidth=2, marker=None, linestyle='solid',
+                color=None, marker_size=10, y_axis='left', x_axis='bottom'):
     """
     Plot the figure on the graph
     Necessary input arguments are self, the canvas to plot the figure on and the
@@ -80,7 +80,7 @@ def set_legend(self, canvas):
         canvas.top_right_axis.legend(lines + lines2 + lines3 + lines4, labels + labels2 + labels3 + labels4, loc=0, frameon=True)
 
 
-def set_canvas_limits_axis(self, canvas, limits={'xmin': None, 'xmax': None, 'ymin': None, 'ymax': None}):
+def set_canvas_limits_axis(self):
     """
     Set the canvas limits for each axis that is present
     """
@@ -91,34 +91,34 @@ def set_canvas_limits_axis(self, canvas, limits={'xmin': None, 'xmax': None, 'ym
             left_items = []
             for key in item_list['left']:
                 left_items.append(key)
-            left_limits = find_limits(self, self.canvas.ax.get_yscale(), canvas, left_items)
+            left_limits = find_limits(self, self.canvas.ax.get_yscale(), left_items)
         if axis == 'right':
             right_items = []
             for key in item_list['right']:
                 right_items.append(key)
-            right_limits = find_limits(self, self.canvas.right_axis.get_yscale(), canvas, right_items)
+            right_limits = find_limits(self, self.canvas.right_axis.get_yscale(), right_items)
         if axis == 'top':
             top_items = []
             for key in item_list['top']:
                 top_items.append(key)
-            top_limits = find_limits(self, axis, canvas, top_items)
+            top_limits = find_limits(self, axis, top_items)
         if axis == 'bottom':
             bottom_items = []
             for key in item_list['bottom']:
                 bottom_items.append(key)
-            bottom_limits = find_limits(self, axis, canvas, bottom_items)
+            bottom_limits = find_limits(self, axis, bottom_items)
     if used_axes['left'] and used_axes['bottom']:
-        set_canvas_limits(self, left_limits, self.canvas.ax, axis_type='Y')
-        set_canvas_limits(self, bottom_limits, self.canvas.ax, axis_type='X')
+        set_canvas_limits(left_limits, self.canvas.ax, axis_type='Y')
+        set_canvas_limits(bottom_limits, self.canvas.ax, axis_type='X')
     if used_axes['left'] and used_axes['top']:
-        set_canvas_limits(self, left_limits, self.canvas.top_left_axis, axis_type='Y')
-        set_canvas_limits(self, top_limits, self.canvas.top_left_axis, axis_type='X')
+        set_canvas_limits(left_limits, self.canvas.top_left_axis, axis_type='Y')
+        set_canvas_limits(top_limits, self.canvas.top_left_axis, axis_type='X')
     if used_axes['right'] and used_axes['bottom']:
-        set_canvas_limits(self, right_limits, self.canvas.right_axis, axis_type='Y')
-        set_canvas_limits(self, bottom_limits, self.canvas.right_axis, axis_type='X')
+        set_canvas_limits(right_limits, self.canvas.right_axis, axis_type='Y')
+        set_canvas_limits(bottom_limits, self.canvas.right_axis, axis_type='X')
     if used_axes['right'] and used_axes['top']:
-        set_canvas_limits(self, right_limits, self.canvas.top_right_axis, axis_type='Y')
-        set_canvas_limits(self, top_limits, self.canvas.top_right_axis, axis_type='X')
+        set_canvas_limits(right_limits, self.canvas.top_right_axis, axis_type='Y')
+        set_canvas_limits(top_limits, self.canvas.top_right_axis, axis_type='X')
 
 
 def get_used_axes(self):
@@ -153,7 +153,7 @@ def get_used_axes(self):
     return used_axis, item_list
 
 
-def set_canvas_limits(self, graph_limits, axis, axis_type, limits={'xmin': None, 'xmax': None, 'ymin': None, 'ymax': None}):
+def set_canvas_limits(graph_limits, axis, axis_type, limits={'xmin': None, 'xmax': None, 'ymin': None, 'ymax': None}):
     """
     Set an calculate the canvas limits for a given axis.
     """
@@ -188,7 +188,7 @@ def set_canvas_limits(self, graph_limits, axis, axis_type, limits={'xmin': None,
         print('Could not set limits, one of the values was probably infinite')
 
 
-def find_limits(self, axis, canvas, datadict):
+def find_limits(self, axis, datadict):
     """
     Find the limits that are to be used for the axes.
     """
@@ -231,7 +231,7 @@ def find_limits(self, axis, canvas, datadict):
     return {'xmin': xmin_all, 'xmax': xmax_all, 'ymin': ymin_all, 'ymax': ymax_all}
 
 
-def reload_plot(self, from_dictionary=True):
+def reload_plot(self):
     """
     Completely reload the plot of the graph
     """
@@ -243,12 +243,12 @@ def reload_plot(self, from_dictionary=True):
             self.highlight.set_visible(False)
             self.highlight.set_active(False)
             self.highlight = None
-        self.set_mode(None, None, self._mode)
-        set_canvas_limits_axis(self, self.canvas)
+        self.set_mode(None, None, self.interaction_mode)
+        set_canvas_limits_axis(self)
     self.canvas.grab_focus()
 
 
-def refresh_plot(self, canvas=None, from_dictionary=True, set_limits=True):
+def refresh_plot(self, canvas=None, set_limits=True):
     """
     Refresh the graph without completely reloading it.
     """
@@ -266,7 +266,7 @@ def refresh_plot(self, canvas=None, from_dictionary=True, set_limits=True):
         hide_unused_axes(self, canvas)
     graphs.open_selection_from_dict(self)
     if set_limits and len(self.datadict) > 0:
-        set_canvas_limits_axis(self, canvas)
+        set_canvas_limits_axis(self)
     self.canvas.draw()
 
 
@@ -282,7 +282,7 @@ def hide_unused_axes(self, canvas):
     right = False
     top = False
     bottom = False
-    for key, item in self.datadict.items():
+    for _key, item in self.datadict.items():
         if item.plot_y_position == 'left':
             left = True
         if item.plot_y_position == 'right':
@@ -319,7 +319,7 @@ def change_left_yscale(action, target, self):
         self.plot_settings.yscale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
-    set_canvas_limits_axis(self, self.canvas)
+    set_canvas_limits_axis(self)
     self.canvas.draw()
 
 
@@ -334,7 +334,7 @@ def change_right_yscale(action, target, self):
         self.plot_settings.right_scale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
-    set_canvas_limits_axis(self, self.canvas)
+    set_canvas_limits_axis(self)
     self.canvas.draw()
 
 
@@ -349,7 +349,7 @@ def change_top_xscale(action, target, self):
         self.plot_settings.top_scale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
-    set_canvas_limits_axis(self, self.canvas)
+    set_canvas_limits_axis(self)
     self.canvas.draw()
 
 
@@ -364,7 +364,7 @@ def change_bottom_xscale(action, target, self):
         self.plot_settings.xscale = 'linear'
     self.canvas.set_ticks(self)
     action.change_state(target)
-    set_canvas_limits_axis(self, self.canvas)
+    set_canvas_limits_axis(self)
     self.canvas.draw()
 
 
@@ -380,16 +380,17 @@ def get_next_color(self):
         item_rows_list = list(item_rows.items())
         item_rows_list = item_rows_list[- color_length + 1:]
         item_rows = dict(item_rows_list)
-    for key, item in item_rows.items():
+    for _key, item in item_rows.items():
         used_colors.append(item.color_picker.color)
     used_colors = [colors.to_rgb(color) for color in used_colors]
 
     for color in color_list:
         if color not in used_colors:
             return color
+    return None
 
 
-def load_fonts(self):
+def load_fonts():
     """
     Load system fonts that are installed on the system
     """

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -46,7 +46,7 @@ def on_highlight_define(self):
     self.highlight.extents = (extend_min, extend_max)
 
 
-def plot_figure(self, canvas, X, Y, filename='', xlim=None, linewidth=2, title='', scale='log', marker=None, linestyle='solid',
+def plot_figure(self, canvas, x_data, y_data, filename='', xlim=None, linewidth=2, title='', scale='log', marker=None, linestyle='solid',
                 revert=False, color=None, marker_size=10, y_axis='left', x_axis='bottom'):
     """
     Plot the figure on the graph
@@ -55,14 +55,14 @@ def plot_figure(self, canvas, X, Y, filename='', xlim=None, linewidth=2, title='
     """
     if y_axis == 'left':
         if x_axis == 'bottom':
-            canvas.ax.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.ax.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
         elif x_axis == 'top':
-            canvas.top_left_axis.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.top_left_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
     elif y_axis == 'right':
         if x_axis == 'bottom':
-            canvas.right_axis.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.right_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
         elif x_axis == 'top':
-            canvas.top_right_axis.plot(X, Y, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
+            canvas.top_right_axis.plot(x_data, y_data, linewidth=linewidth, label=filename, linestyle=linestyle, marker=marker, color=color, markersize=marker_size)
             canvas.top_right_axis.set_yscale(self.plot_settings.right_scale)
     set_legend(self, canvas)
 

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -19,10 +19,10 @@ class Preferences():
         self.check_config(self.config)
 
     def check_config(self, config):
-        template_path = os.path.join(os.getenv("XDG_DATA_DIRS"))
-        template_path = template_path.split(":")[0] + "/graphs/graphs"
+        template_path = os.path.join(os.getenv('XDG_DATA_DIRS'))
+        template_path = template_path.split(':')[0] + '/graphs/graphs'
         os.chdir(template_path)
-        with open("config.json", 'r') as f:
+        with open('config.json', 'r') as f:
             template = json.load(f)
         if set(config.keys()) != set(template.keys()):
             config = utilities.remove_unused_config_keys(config, template)
@@ -31,26 +31,26 @@ class Preferences():
         
     def create_new_config_file(self):
         config_path = self.get_config_path()
-        if not os.path.isfile(f"{config_path}/config.json"):
+        if not os.path.isfile(f'{config_path}/config.json'):
             self.reset_config()    
-            print("New configuration file created")
+            print('New configuration file created')
         else:
-            print("Loading configuration file")
+            print('Loading configuration file')
 
     def reset_config(self):
         config_path = self.get_config_path()
-        old_path = os.path.join(os.getenv("XDG_DATA_DIRS"))
-        old_path = old_path.split(":")[0] + "/graphs/graphs"
+        old_path = os.path.join(os.getenv('XDG_DATA_DIRS'))
+        old_path = old_path.split(':')[0] + '/graphs/graphs'
         if not os.path.isdir(config_path):
             os.mkdir(config_path)
-        path = config_path + "/config.json"
-        shutil.copy(f"{old_path}/config.json", path)
-        print("Loaded new config")
+        path = config_path + '/config.json'
+        shutil.copy(f'{old_path}/config.json', path)
+        print('Loaded new config')
 
     def load_config(self):
         config_path = self.get_config_path()
         os.chdir(config_path)
-        with open("config.json", 'r') as f:
+        with open('config.json', 'r') as f:
             config = json.load(f)
         config = self.check_config(config)
         return config
@@ -58,19 +58,19 @@ class Preferences():
     def save_config(self):
         config_path = self.get_config_path()
         os.chdir(config_path)
-        with open("config.json", 'w') as f:
+        with open('config.json', 'w') as f:
             json.dump(self.config, f)
 
     def get_config_path(self) -> str:
-        if os.getenv("XDG_CONFIG_HOME"):
-            return os.path.join(os.getenv("XDG_CONFIG_HOME"), "Graphs")
+        if os.getenv('XDG_CONFIG_HOME'):
+            return os.path.join(os.getenv('XDG_CONFIG_HOME'), 'Graphs')
         else:
-            return os.path.join(str(Path.home()), ".local", "share", "Graphs")
+            return os.path.join(str(Path.home()), '.local', 'share', 'Graphs')
 
 
-@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/preferences.ui")
+@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/preferences.ui')
 class PreferencesWindow(Adw.PreferencesWindow):
-    __gtype_name__ = "PreferencesWindow"
+    __gtype_name__ = 'PreferencesWindow'
     selected_line_thickness_slider = Gtk.Template.Child()
     unselected_line_thickness_slider = Gtk.Template.Child()
     savefig_transparent_check_button = Gtk.Template.Child()
@@ -135,11 +135,11 @@ class PreferencesWindow(Adw.PreferencesWindow):
         utilities.populate_chooser(self.plot_unselected_markers_chooser, list(Line2D.markers.values()), clear = False)
         config = parent.preferences.config
         config = self.load_configuration(config)
-        self.connect("close-request", self.on_close, parent)
+        self.connect('close-request', self.on_close, parent)
         self.set_transient_for(parent.main_window)
 
     def load_configuration(self, config):
-        font_string = config["plot_font_string"]
+        font_string = config['plot_font_string']
         font_desc = self.plot_font_chooser.get_font_desc().from_string(font_string)
         self.plot_font_chooser.set_font_desc(font_desc)
         self.plot_font_chooser.set_use_font(True)
@@ -151,79 +151,79 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.plot_minor_tick_length.set_range(0, 20)
         self.plot_selected_marker_size.set_range(0, 30)
         self.plot_unselected_marker_size.set_range(0, 30)
-        self.addequation_equation.set_text(str(config["addequation_equation"]))
-        self.addequation_X_start.set_text(str(config["addequation_X_start"]))
-        self.addequation_X_stop.set_text(str(config["addequation_X_stop"]))    
-        self.addequation_step_size.set_text(str(config["addequation_step_size"]))          
-        self.import_skip_rows.set_value(int(config["import_skip_rows"]))
-        self.column_y.set_value(int(config["import_column_y"]))
-        self.column_x.set_value(int(config["import_column_x"]))
-        self.import_delimiter.set_text(config["import_delimiter"])
-        self.plot_selected_marker_size.set_value(config["plot_selected_marker_size"])
-        self.plot_unselected_marker_size.set_value(config["plot_unselected_marker_size"])
-        self.unselected_line_thickness_slider.set_value(config["unselected_linewidth"])
-        self.selected_line_thickness_slider.set_value(config["selected_linewidth"])
-        self.plot_minor_tick_width.set_value(config["plot_minor_tick_width"])
-        self.plot_major_tick_width.set_value(config["plot_major_tick_width"])
-        self.plot_minor_tick_length.set_value(config["plot_minor_tick_length"])
-        self.plot_major_tick_length.set_value(config["plot_major_tick_length"])
-        self.plot_Y_label.set_text(config["plot_Y_label"])
-        self.plot_X_label.set_text(config["plot_X_label"])
-        self.plot_right_label.set_text(config["plot_right_label"])
-        self.plot_top_label.set_text(config["plot_top_label"])
-        self.plot_title.set_text(config["plot_title"])
-        utilities.set_chooser(self.savefig_filetype_chooser, config["savefig_filetype"])
-        utilities.set_chooser(self.center_data_chooser, config["action_center_data"])
-        utilities.set_chooser(self.plot_X_scale, config["plot_X_scale"])
-        utilities.set_chooser(self.plot_top_scale, config["plot_top_scale"])
-        utilities.set_chooser(self.plot_right_scale, config["plot_right_scale"])
-        utilities.set_chooser(self.plot_Y_scale, config["plot_Y_scale"])
-        utilities.set_chooser(self.plot_X_position, config["plot_X_position"])
-        utilities.set_chooser(self.plot_Y_position, config["plot_Y_position"])
-        utilities.set_chooser(self.plot_tick_direction, config["plot_tick_direction"])
-        utilities.set_chooser(self.handle_duplicates_chooser, config["handle_duplicates"])
-        utilities.set_chooser(self.import_separator, config["import_separator"])
-        utilities.set_chooser(self.plot_color_cycle, config["plot_color_cycle"])
-        utilities.set_chooser(self.plot_selected_linestyle_chooser, config["plot_selected_linestyle"])
-        utilities.set_chooser(self.plot_unselected_linestyle_chooser, config["plot_unselected_linestyle"])
-        utilities.set_chooser(self.plot_style_light, config["plot_style_light"])
-        utilities.set_chooser(self.plot_style_dark, config["plot_style_dark"])
+        self.addequation_equation.set_text(str(config['addequation_equation']))
+        self.addequation_X_start.set_text(str(config['addequation_X_start']))
+        self.addequation_X_stop.set_text(str(config['addequation_X_stop']))    
+        self.addequation_step_size.set_text(str(config['addequation_step_size']))          
+        self.import_skip_rows.set_value(int(config['import_skip_rows']))
+        self.column_y.set_value(int(config['import_column_y']))
+        self.column_x.set_value(int(config['import_column_x']))
+        self.import_delimiter.set_text(config['import_delimiter'])
+        self.plot_selected_marker_size.set_value(config['plot_selected_marker_size'])
+        self.plot_unselected_marker_size.set_value(config['plot_unselected_marker_size'])
+        self.unselected_line_thickness_slider.set_value(config['unselected_linewidth'])
+        self.selected_line_thickness_slider.set_value(config['selected_linewidth'])
+        self.plot_minor_tick_width.set_value(config['plot_minor_tick_width'])
+        self.plot_major_tick_width.set_value(config['plot_major_tick_width'])
+        self.plot_minor_tick_length.set_value(config['plot_minor_tick_length'])
+        self.plot_major_tick_length.set_value(config['plot_major_tick_length'])
+        self.plot_Y_label.set_text(config['plot_Y_label'])
+        self.plot_X_label.set_text(config['plot_X_label'])
+        self.plot_right_label.set_text(config['plot_right_label'])
+        self.plot_top_label.set_text(config['plot_top_label'])
+        self.plot_title.set_text(config['plot_title'])
+        utilities.set_chooser(self.savefig_filetype_chooser, config['savefig_filetype'])
+        utilities.set_chooser(self.center_data_chooser, config['action_center_data'])
+        utilities.set_chooser(self.plot_X_scale, config['plot_X_scale'])
+        utilities.set_chooser(self.plot_top_scale, config['plot_top_scale'])
+        utilities.set_chooser(self.plot_right_scale, config['plot_right_scale'])
+        utilities.set_chooser(self.plot_Y_scale, config['plot_Y_scale'])
+        utilities.set_chooser(self.plot_X_position, config['plot_X_position'])
+        utilities.set_chooser(self.plot_Y_position, config['plot_Y_position'])
+        utilities.set_chooser(self.plot_tick_direction, config['plot_tick_direction'])
+        utilities.set_chooser(self.handle_duplicates_chooser, config['handle_duplicates'])
+        utilities.set_chooser(self.import_separator, config['import_separator'])
+        utilities.set_chooser(self.plot_color_cycle, config['plot_color_cycle'])
+        utilities.set_chooser(self.plot_selected_linestyle_chooser, config['plot_selected_linestyle'])
+        utilities.set_chooser(self.plot_unselected_linestyle_chooser, config['plot_unselected_linestyle'])
+        utilities.set_chooser(self.plot_style_light, config['plot_style_light'])
+        utilities.set_chooser(self.plot_style_dark, config['plot_style_dark'])
         marker_dict = Line2D.markers
-        unselected_marker_value = marker_dict[config["plot_unselected_markers"]]
-        selected_marker_value = marker_dict[config["plot_selected_markers"]]
+        unselected_marker_value = marker_dict[config['plot_unselected_markers']]
+        selected_marker_value = marker_dict[config['plot_selected_markers']]
         utilities.set_chooser(self.plot_selected_markers_chooser, selected_marker_value)
         utilities.set_chooser(self.plot_unselected_markers_chooser, unselected_marker_value)
-        if config["plot_tick_left"]:
+        if config['plot_tick_left']:
             self.plot_tick_left.set_active(True)
-        if config["plot_tick_right"]:
+        if config['plot_tick_right']:
             self.plot_tick_right.set_active(True)
-        if config["plot_tick_bottom"]:
+        if config['plot_tick_bottom']:
             self.plot_tick_bottom.set_active(True)
-        if config["plot_tick_top"]:
+        if config['plot_tick_top']:
             self.plot_tick_top.set_active(True)
-        if config["guess_headers"]:
+        if config['guess_headers']:
             self.guess_headers.set_active(True)
-        if config["savefig_transparent"]:
+        if config['savefig_transparent']:
             self.savefig_transparent_check_button.set_active(True)
-        if config["plot_legend"]:
+        if config['plot_legend']:
             self.plot_legend_check.set_active(True)
-        if config["plot_invert_color_cycle_dark"]:
+        if config['plot_invert_color_cycle_dark']:
             self.plot_invert_color_cycle_dark.set_active(True)
         return config
 
     def get_font_weight(self, font_name):
         valid_weights = ['normal', 'bold', 'heavy', 'light', 'ultrabold', 'ultralight']
-        if font_name[-2] != "italic":
+        if font_name[-2] != 'italic':
             new_weight = font_name[-2]
         else:
             new_weight = font_name[-3]
         if new_weight not in valid_weights:
-            new_weight = "normal"
+            new_weight = 'normal'
         return new_weight
 
     def get_font_style(self, font_name):
-        new_style = "normal"
-        if font_name[-2] == ("italic" or "oblique" or "normal"):
+        new_style = 'normal'
+        if font_name[-2] == ('italic' or 'oblique' or 'normal'):
             new_style = font_name[-2]
         return new_style
 
@@ -237,67 +237,67 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     def set_config(self):
         config = dict()
-        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(" ")
+        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(' ')
         font_size = font_name[-1]
         font_weight = self.get_font_weight(font_name)
         font_style = self.get_font_style(font_name)
-        config["addequation_equation"] = self.addequation_equation.get_text()
-        config["addequation_X_start"] = self.addequation_X_start.get_text()
-        config["addequation_X_stop"] = self.addequation_X_stop.get_text()
-        config["addequation_step_size"] = self.addequation_step_size.get_text()
-        config["plot_font_string"] = self.plot_font_chooser.get_font_desc().to_string()
-        config["plot_selected_marker_size"] = self.plot_selected_marker_size.get_value()
-        config["plot_unselected_marker_size"] = self.plot_unselected_marker_size.get_value()
-        config["selected_linewidth"] = self.selected_line_thickness_slider.get_value()
-        config["unselected_linewidth"] = self.unselected_line_thickness_slider.get_value()
-        config["plot_major_tick_width"] = self.plot_major_tick_width.get_value()
-        config["plot_minor_tick_width"] = self.plot_minor_tick_width.get_value()
-        config["plot_major_tick_length"] = self.plot_major_tick_length.get_value()
-        config["plot_minor_tick_length"] = self.plot_minor_tick_length.get_value()
-        config["plot_tick_left"] = self.plot_tick_left.get_active()
-        config["plot_tick_right"] = self.plot_tick_right.get_active()
-        config["plot_tick_top"] = self.plot_tick_top.get_active()
-        config["plot_tick_bottom"] = self.plot_tick_bottom.get_active()
-        config["plot_tick_direction"] = self.plot_tick_direction.get_selected_item().get_string()
-        config["guess_headers"] = self.guess_headers.get_active()
-        config["handle_duplicates"] = self.handle_duplicates_chooser.get_selected_item().get_string()
-        config["savefig_transparent"] = self.savefig_transparent_check_button.get_active()
-        config["plot_legend"] = self.plot_legend_check.get_active()
-        config["plot_invert_color_cycle_dark"] = self.plot_invert_color_cycle_dark.get_active()
-        config["plot_Y_label"] = self.plot_Y_label.get_text()
-        config["plot_X_label"] = self.plot_X_label.get_text()
-        config["plot_right_label"] = self.plot_right_label.get_text()
-        config["plot_top_label"] = self.plot_top_label.get_text()
-        config["plot_font_size"] = font_size
-        config["plot_font_style"] = font_style
-        config["plot_font_weight"] = font_weight
-        config["plot_font_family"] = self.plot_font_chooser.get_font_desc().get_family()
-        config["plot_title"] = self.plot_title.get_text()
-        config["savefig_filetype"] = self.savefig_filetype_chooser.get_selected_item().get_string()
-        config["plot_color_cycle"] = self.plot_color_cycle.get_selected_item().get_string()
-        config["plot_X_scale"] = self.plot_X_scale.get_selected_item().get_string()
-        config["plot_Y_scale"] = self.plot_Y_scale.get_selected_item().get_string()
-        config["plot_top_scale"] = self.plot_top_scale.get_selected_item().get_string()
-        config["plot_right_scale"] = self.plot_right_scale.get_selected_item().get_string()
-        config["plot_right_scale"] = self.plot_right_scale.get_selected_item().get_string()
-        config["plot_top_scale"] = self.plot_top_scale.get_selected_item().get_string()
-        config["plot_X_position"] = self.plot_X_position.get_selected_item().get_string()
-        config["plot_Y_position"] = self.plot_Y_position.get_selected_item().get_string()
-        config["action_center_data"] = self.center_data_chooser.get_selected_item().get_string()
-        config["plot_selected_linestyle"] = self.plot_selected_linestyle_chooser.get_selected_item().get_string()
-        config["plot_unselected_linestyle"] = self.plot_unselected_linestyle_chooser.get_selected_item().get_string()
-        config["plot_style_dark"] = self.plot_style_dark.get_selected_item().get_string()
-        config["plot_style_light"] = self.plot_style_light.get_selected_item().get_string()
-        config["import_column_x"] = int(self.column_x.get_value())
-        config["import_column_y"] = int(self.column_y.get_value())
-        config["import_skip_rows"] = int(self.import_skip_rows.get_value())
-        config["import_separator"] = self.import_separator.get_selected_item().get_string()
-        config["import_delimiter"] = self.import_delimiter.get_text()
+        config['addequation_equation'] = self.addequation_equation.get_text()
+        config['addequation_X_start'] = self.addequation_X_start.get_text()
+        config['addequation_X_stop'] = self.addequation_X_stop.get_text()
+        config['addequation_step_size'] = self.addequation_step_size.get_text()
+        config['plot_font_string'] = self.plot_font_chooser.get_font_desc().to_string()
+        config['plot_selected_marker_size'] = self.plot_selected_marker_size.get_value()
+        config['plot_unselected_marker_size'] = self.plot_unselected_marker_size.get_value()
+        config['selected_linewidth'] = self.selected_line_thickness_slider.get_value()
+        config['unselected_linewidth'] = self.unselected_line_thickness_slider.get_value()
+        config['plot_major_tick_width'] = self.plot_major_tick_width.get_value()
+        config['plot_minor_tick_width'] = self.plot_minor_tick_width.get_value()
+        config['plot_major_tick_length'] = self.plot_major_tick_length.get_value()
+        config['plot_minor_tick_length'] = self.plot_minor_tick_length.get_value()
+        config['plot_tick_left'] = self.plot_tick_left.get_active()
+        config['plot_tick_right'] = self.plot_tick_right.get_active()
+        config['plot_tick_top'] = self.plot_tick_top.get_active()
+        config['plot_tick_bottom'] = self.plot_tick_bottom.get_active()
+        config['plot_tick_direction'] = self.plot_tick_direction.get_selected_item().get_string()
+        config['guess_headers'] = self.guess_headers.get_active()
+        config['handle_duplicates'] = self.handle_duplicates_chooser.get_selected_item().get_string()
+        config['savefig_transparent'] = self.savefig_transparent_check_button.get_active()
+        config['plot_legend'] = self.plot_legend_check.get_active()
+        config['plot_invert_color_cycle_dark'] = self.plot_invert_color_cycle_dark.get_active()
+        config['plot_Y_label'] = self.plot_Y_label.get_text()
+        config['plot_X_label'] = self.plot_X_label.get_text()
+        config['plot_right_label'] = self.plot_right_label.get_text()
+        config['plot_top_label'] = self.plot_top_label.get_text()
+        config['plot_font_size'] = font_size
+        config['plot_font_style'] = font_style
+        config['plot_font_weight'] = font_weight
+        config['plot_font_family'] = self.plot_font_chooser.get_font_desc().get_family()
+        config['plot_title'] = self.plot_title.get_text()
+        config['savefig_filetype'] = self.savefig_filetype_chooser.get_selected_item().get_string()
+        config['plot_color_cycle'] = self.plot_color_cycle.get_selected_item().get_string()
+        config['plot_X_scale'] = self.plot_X_scale.get_selected_item().get_string()
+        config['plot_Y_scale'] = self.plot_Y_scale.get_selected_item().get_string()
+        config['plot_top_scale'] = self.plot_top_scale.get_selected_item().get_string()
+        config['plot_right_scale'] = self.plot_right_scale.get_selected_item().get_string()
+        config['plot_right_scale'] = self.plot_right_scale.get_selected_item().get_string()
+        config['plot_top_scale'] = self.plot_top_scale.get_selected_item().get_string()
+        config['plot_X_position'] = self.plot_X_position.get_selected_item().get_string()
+        config['plot_Y_position'] = self.plot_Y_position.get_selected_item().get_string()
+        config['action_center_data'] = self.center_data_chooser.get_selected_item().get_string()
+        config['plot_selected_linestyle'] = self.plot_selected_linestyle_chooser.get_selected_item().get_string()
+        config['plot_unselected_linestyle'] = self.plot_unselected_linestyle_chooser.get_selected_item().get_string()
+        config['plot_style_dark'] = self.plot_style_dark.get_selected_item().get_string()
+        config['plot_style_light'] = self.plot_style_light.get_selected_item().get_string()
+        config['import_column_x'] = int(self.column_x.get_value())
+        config['import_column_y'] = int(self.column_y.get_value())
+        config['import_skip_rows'] = int(self.import_skip_rows.get_value())
+        config['import_separator'] = self.import_separator.get_selected_item().get_string()
+        config['import_delimiter'] = self.import_delimiter.get_text()
         marker_dict = Line2D.markers
         unselected_marker_value = utilities.get_dict_by_value(marker_dict, self.plot_unselected_markers_chooser.get_selected_item().get_string())
         selected_marker_value = utilities.get_dict_by_value(marker_dict, self.plot_selected_markers_chooser.get_selected_item().get_string())
-        config["plot_unselected_markers"] = unselected_marker_value
-        config["plot_selected_markers"] = selected_marker_value
+        config['plot_unselected_markers'] = unselected_marker_value
+        config['plot_selected_markers'] = selected_marker_value
         return config
 
     def on_close(self, _, parent):

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -2,6 +2,7 @@
 import json
 import os
 import shutil
+from pathlib import Path
 
 from gi.repository import Adw, Gtk
 
@@ -23,7 +24,7 @@ class Preferences():
         template_path = os.path.join(os.getenv('XDG_DATA_DIRS'))
         template_path = template_path.split(':')[0] + '/graphs/graphs'
         os.chdir(template_path)
-        with open('config.json', 'r') as file:
+        with open('config.json', 'r', encoding='utf-8') as file:
             template = json.load(file)
         if set(config.keys()) != set(template.keys()):
             config = utilities.remove_unused_config_keys(config, template)
@@ -65,8 +66,7 @@ class Preferences():
     def get_config_path(self) -> str:
         if os.getenv('XDG_CONFIG_HOME'):
             return os.path.join(os.getenv('XDG_CONFIG_HOME'), 'Graphs')
-        else:
-            return os.path.join(str(Path.home()), '.local', 'share', 'Graphs')
+        return os.path.join(str(Path.home()), '.local', 'share', 'Graphs')
 
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/preferences.ui')

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -23,8 +23,8 @@ class Preferences():
         template_path = os.path.join(os.getenv('XDG_DATA_DIRS'))
         template_path = template_path.split(':')[0] + '/graphs/graphs'
         os.chdir(template_path)
-        with open('config.json', 'r') as f:
-            template = json.load(f)
+        with open('config.json', 'r') as file:
+            template = json.load(file)
         if set(config.keys()) != set(template.keys()):
             config = utilities.remove_unused_config_keys(config, template)
             config = utilities.add_new_config_keys(config, template)
@@ -51,16 +51,16 @@ class Preferences():
     def load_config(self):
         config_path = self.get_config_path()
         os.chdir(config_path)
-        with open('config.json', 'r') as f:
-            config = json.load(f)
+        with open('config.json', 'r') as file:
+            config = json.load(file)
         config = self.check_config(config)
         return config
 
     def save_config(self):
         config_path = self.get_config_path()
         os.chdir(config_path)
-        with open('config.json', 'w') as f:
-            json.dump(self.config, f)
+        with open('config.json', 'w') as file:
+            json.dump(self.config, file)
 
     def get_config_path(self) -> str:
         if os.getenv('XDG_CONFIG_HOME'):

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -132,8 +132,10 @@ class PreferencesWindow(Adw.PreferencesWindow):
         utilities.populate_chooser(self.plot_color_cycle, color_cycles)
         utilities.populate_chooser(self.plot_style_dark, plt.style.available)
         utilities.populate_chooser(self.plot_style_light, plt.style.available)
-        utilities.populate_chooser(self.plot_selected_markers_chooser, list(Line2D.markers.values()), clear=False)
-        utilities.populate_chooser(self.plot_unselected_markers_chooser, list(Line2D.markers.values()), clear=False)
+        utilities.populate_chooser(self.plot_selected_markers_chooser,
+                                   list(Line2D.markers.values()), clear=False)
+        utilities.populate_chooser(self.plot_unselected_markers_chooser,
+                                   list(Line2D.markers.values()), clear=False)
         config = parent.preferences.config
         config = self.load_configuration(config)
         self.connect("close-request", self.on_close, parent)
@@ -141,7 +143,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     def load_configuration(self, config):
         font_string = config["plot_font_string"]
-        font_desc = self.plot_font_chooser.get_font_desc().from_string(font_string)
+        font_desc = self.plot_font_chooser.get_font_desc().from_string(
+            font_string)
         self.plot_font_chooser.set_font_desc(font_desc)
         self.plot_font_chooser.set_use_font(True)
         self.selected_line_thickness_slider.set_range(0.1, 10)
@@ -155,15 +158,20 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.addequation_equation.set_text(str(config["addequation_equation"]))
         self.addequation_X_start.set_text(str(config["addequation_X_start"]))
         self.addequation_X_stop.set_text(str(config["addequation_X_stop"]))
-        self.addequation_step_size.set_text(str(config["addequation_step_size"]))
+        self.addequation_step_size.set_text(str(config[
+            "addequation_step_size"]))
         self.import_skip_rows.set_value(int(config["import_skip_rows"]))
         self.column_y.set_value(int(config["import_column_y"]))
         self.column_x.set_value(int(config["import_column_x"]))
         self.import_delimiter.set_text(config["import_delimiter"])
-        self.plot_selected_marker_size.set_value(config["plot_selected_marker_size"])
-        self.plot_unselected_marker_size.set_value(config["plot_unselected_marker_size"])
-        self.unselected_line_thickness_slider.set_value(config["unselected_linewidth"])
-        self.selected_line_thickness_slider.set_value(config["selected_linewidth"])
+        self.plot_selected_marker_size.set_value(config[
+            "plot_selected_marker_size"])
+        self.plot_unselected_marker_size.set_value(config[
+            "plot_unselected_marker_size"])
+        self.unselected_line_thickness_slider.set_value(config[
+            "unselected_linewidth"])
+        self.selected_line_thickness_slider.set_value(config[
+            "selected_linewidth"])
         self.plot_minor_tick_width.set_value(config["plot_minor_tick_width"])
         self.plot_major_tick_width.set_value(config["plot_major_tick_width"])
         self.plot_minor_tick_length.set_value(config["plot_minor_tick_length"])
@@ -173,27 +181,40 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.plot_right_label.set_text(config["plot_right_label"])
         self.plot_top_label.set_text(config["plot_top_label"])
         self.plot_title.set_text(config["plot_title"])
-        utilities.set_chooser(self.savefig_filetype_chooser, config["savefig_filetype"])
-        utilities.set_chooser(self.center_data_chooser, config["action_center_data"])
+        utilities.set_chooser(self.savefig_filetype_chooser, config[
+            "savefig_filetype"])
+        utilities.set_chooser(self.center_data_chooser, config[
+            "action_center_data"])
         utilities.set_chooser(self.plot_X_scale, config["plot_X_scale"])
         utilities.set_chooser(self.plot_top_scale, config["plot_top_scale"])
-        utilities.set_chooser(self.plot_right_scale, config["plot_right_scale"])
+        utilities.set_chooser(self.plot_right_scale, config[
+            "plot_right_scale"])
         utilities.set_chooser(self.plot_Y_scale, config["plot_Y_scale"])
         utilities.set_chooser(self.plot_X_position, config["plot_X_position"])
         utilities.set_chooser(self.plot_Y_position, config["plot_Y_position"])
-        utilities.set_chooser(self.plot_tick_direction, config["plot_tick_direction"])
-        utilities.set_chooser(self.handle_duplicates_chooser, config["handle_duplicates"])
-        utilities.set_chooser(self.import_separator, config["import_separator"])
-        utilities.set_chooser(self.plot_color_cycle, config["plot_color_cycle"])
-        utilities.set_chooser(self.plot_selected_linestyle_chooser, config["plot_selected_linestyle"])
-        utilities.set_chooser(self.plot_unselected_linestyle_chooser, config["plot_unselected_linestyle"])
-        utilities.set_chooser(self.plot_style_light, config["plot_style_light"])
+        utilities.set_chooser(self.plot_tick_direction, config[
+            "plot_tick_direction"])
+        utilities.set_chooser(self.handle_duplicates_chooser, config[
+            "handle_duplicates"])
+        utilities.set_chooser(self.import_separator, config[
+            "import_separator"])
+        utilities.set_chooser(self.plot_color_cycle, config[
+            "plot_color_cycle"])
+        utilities.set_chooser(self.plot_selected_linestyle_chooser, config[
+            "plot_selected_linestyle"])
+        utilities.set_chooser(self.plot_unselected_linestyle_chooser, config[
+            "plot_unselected_linestyle"])
+        utilities.set_chooser(self.plot_style_light, config[
+            "plot_style_light"])
         utilities.set_chooser(self.plot_style_dark, config["plot_style_dark"])
         marker_dict = Line2D.markers
-        unselected_marker_value = marker_dict[config["plot_unselected_markers"]]
+        unselected_marker_value = marker_dict[config[
+            "plot_unselected_markers"]]
         selected_marker_value = marker_dict[config["plot_selected_markers"]]
-        utilities.set_chooser(self.plot_selected_markers_chooser, selected_marker_value)
-        utilities.set_chooser(self.plot_unselected_markers_chooser, unselected_marker_value)
+        utilities.set_chooser(
+            self.plot_selected_markers_chooser, selected_marker_value)
+        utilities.set_chooser(
+            self.plot_unselected_markers_chooser, unselected_marker_value)
         if config["plot_tick_left"]:
             self.plot_tick_left.set_active(True)
         if config["plot_tick_right"]:
@@ -213,7 +234,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         return config
 
     def get_font_weight(self, font_name):
-        valid_weights = ["normal", "bold", "heavy", "light", "ultrabold", "ultralight"]
+        valid_weights = [
+            "normal", "bold", "heavy", "light", "ultrabold", "ultralight"]
         if font_name[-2] != "italic":
             new_weight = font_name[-2]
         else:
@@ -237,7 +259,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     def set_config(self):
         config = {}
-        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(" ")
+        font_description = self.plot_font_chooser.get_font_desc()
+        font_name = font_description.to_string().lower().split(" ")
         font_size = font_name[-1]
         font_weight = self.get_font_weight(font_name)
         font_style = self.get_font_style(font_name)
@@ -245,25 +268,40 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["addequation_X_start"] = self.addequation_X_start.get_text()
         config["addequation_X_stop"] = self.addequation_X_stop.get_text()
         config["addequation_step_size"] = self.addequation_step_size.get_text()
-        config["plot_font_string"] = self.plot_font_chooser.get_font_desc().to_string()
-        config["plot_selected_marker_size"] = self.plot_selected_marker_size.get_value()
-        config["plot_unselected_marker_size"] = self.plot_unselected_marker_size.get_value()
-        config["selected_linewidth"] = self.selected_line_thickness_slider.get_value()
-        config["unselected_linewidth"] = self.unselected_line_thickness_slider.get_value()
-        config["plot_major_tick_width"] = self.plot_major_tick_width.get_value()
-        config["plot_minor_tick_width"] = self.plot_minor_tick_width.get_value()
-        config["plot_major_tick_length"] = self.plot_major_tick_length.get_value()
-        config["plot_minor_tick_length"] = self.plot_minor_tick_length.get_value()
+        config["plot_font_string"] = self.plot_font_chooser.get_font_desc(
+        ).to_string()
+        selected_marker = self.plot_selected_marker_size
+        config["plot_selected_marker_size"] = selected_marker.get_value()
+        unselected_marker = self.plot_unselected_marker_size
+        config["plot_unselected_marker_size"] = unselected_marker.get_value()
+        selected_thickness = self.selected_line_thickness_slider
+        config["selected_linewidth"] = selected_thickness.get_value()
+        unselected_linewidth = self.unselected_line_thickness_slider
+        config["unselected_linewidth"] = unselected_linewidth.get_value()
+        config[
+            "plot_major_tick_width"] = self.plot_major_tick_width.get_value()
+        config[
+            "plot_minor_tick_width"] = self.plot_minor_tick_width.get_value()
+        config[
+            "plot_major_tick_length"] = self.plot_major_tick_length.get_value()
+        config[
+            "plot_minor_tick_length"] = self.plot_minor_tick_length.get_value()
         config["plot_tick_left"] = self.plot_tick_left.get_active()
         config["plot_tick_right"] = self.plot_tick_right.get_active()
         config["plot_tick_top"] = self.plot_tick_top.get_active()
         config["plot_tick_bottom"] = self.plot_tick_bottom.get_active()
-        config["plot_tick_direction"] = self.plot_tick_direction.get_selected_item().get_string()
+        tick_direction = self.plot_tick_direction
+        config["plot_tick_direction"] = tick_direction.get_selected_item(
+        ).get_string()
         config["guess_headers"] = self.guess_headers.get_active()
-        config["handle_duplicates"] = self.handle_duplicates_chooser.get_selected_item().get_string()
-        config["savefig_transparent"] = self.savefig_transparent_check_button.get_active()
+        handle_duplicates = self.handle_duplicates_chooser
+        config["handle_duplicates"] = handle_duplicates.get_selected_item(
+        ).get_string()
+        transparent = self.savefig_transparent_check_button
+        config["savefig_transparent"] = transparent.get_active()
         config["plot_legend"] = self.plot_legend_check.get_active()
-        config["plot_invert_color_cycle_dark"] = self.plot_invert_color_cycle_dark.get_active()
+        invert_color = self.plot_invert_color_cycle_dark
+        config["plot_invert_color_cycle_dark"] = invert_color.get_active()
         config["plot_Y_label"] = self.plot_Y_label.get_text()
         config["plot_X_label"] = self.plot_X_label.get_text()
         config["plot_right_label"] = self.plot_right_label.get_text()
@@ -271,31 +309,59 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["plot_font_size"] = font_size
         config["plot_font_style"] = font_style
         config["plot_font_weight"] = font_weight
-        config["plot_font_family"] = self.plot_font_chooser.get_font_desc().get_family()
+        config["plot_font_family"] = self.plot_font_chooser.get_font_desc(
+        ).get_family()
         config["plot_title"] = self.plot_title.get_text()
-        config["savefig_filetype"] = self.savefig_filetype_chooser.get_selected_item().get_string()
-        config["plot_color_cycle"] = self.plot_color_cycle.get_selected_item().get_string()
-        config["plot_X_scale"] = self.plot_X_scale.get_selected_item().get_string()
-        config["plot_Y_scale"] = self.plot_Y_scale.get_selected_item().get_string()
-        config["plot_top_scale"] = self.plot_top_scale.get_selected_item().get_string()
-        config["plot_right_scale"] = self.plot_right_scale.get_selected_item().get_string()
-        config["plot_right_scale"] = self.plot_right_scale.get_selected_item().get_string()
-        config["plot_top_scale"] = self.plot_top_scale.get_selected_item().get_string()
-        config["plot_X_position"] = self.plot_X_position.get_selected_item().get_string()
-        config["plot_Y_position"] = self.plot_Y_position.get_selected_item().get_string()
-        config["action_center_data"] = self.center_data_chooser.get_selected_item().get_string()
-        config["plot_selected_linestyle"] = self.plot_selected_linestyle_chooser.get_selected_item().get_string()
-        config["plot_unselected_linestyle"] = self.plot_unselected_linestyle_chooser.get_selected_item().get_string()
-        config["plot_style_dark"] = self.plot_style_dark.get_selected_item().get_string()
-        config["plot_style_light"] = self.plot_style_light.get_selected_item().get_string()
+        filetype = self.savefig_filetype_chooser
+        config[
+            "savefig_filetype"] = filetype.get_selected_item().get_string()
+        config["plot_color_cycle"] = self.plot_color_cycle.get_selected_item(
+        ).get_string()
+        config["plot_X_scale"] = self.plot_X_scale.get_selected_item(
+        ).get_string()
+        config["plot_Y_scale"] = self.plot_Y_scale.get_selected_item(
+        ).get_string()
+        config["plot_top_scale"] = self.plot_top_scale.get_selected_item(
+        ).get_string()
+        config["plot_right_scale"] = self.plot_right_scale.get_selected_item(
+        ).get_string()
+        config["plot_right_scale"] = self.plot_right_scale.get_selected_item(
+        ).get_string()
+        config["plot_top_scale"] = self.plot_top_scale.get_selected_item(
+        ).get_string()
+        config["plot_X_position"] = self.plot_X_position.get_selected_item(
+        ).get_string()
+        config["plot_Y_position"] = self.plot_Y_position.get_selected_item(
+        ).get_string()
+        config[
+            "action_center_data"] = self.center_data_chooser.get_selected_item(
+        ).get_string()
+        selected_linestyle = self.plot_selected_linestyle_chooser
+        config[
+            "plot_selected_linestyle"] = selected_linestyle.get_selected_item(
+        ).get_string()
+        unselected_line = self.plot_unselected_linestyle_chooser
+        config[
+            "plot_unselected_linestyle"] = unselected_line.get_selected_item(
+        ).get_string()
+        config["plot_style_dark"] = self.plot_style_dark.get_selected_item(
+        ).get_string()
+        config["plot_style_light"] = self.plot_style_light.get_selected_item(
+        ).get_string()
         config["import_column_x"] = int(self.column_x.get_value())
         config["import_column_y"] = int(self.column_y.get_value())
         config["import_skip_rows"] = int(self.import_skip_rows.get_value())
-        config["import_separator"] = self.import_separator.get_selected_item().get_string()
+        config["import_separator"] = self.import_separator.get_selected_item(
+        ).get_string()
         config["import_delimiter"] = self.import_delimiter.get_text()
         marker_dict = Line2D.markers
-        unselected_marker_value = utilities.get_dict_by_value(marker_dict, self.plot_unselected_markers_chooser.get_selected_item().get_string())
-        selected_marker_value = utilities.get_dict_by_value(marker_dict, self.plot_selected_markers_chooser.get_selected_item().get_string())
+        unselected_marker_value = utilities.get_dict_by_value(
+            marker_dict,
+            self.plot_unselected_markers_chooser.get_selected_item(
+            ).get_string())
+        selected_marker_value = utilities.get_dict_by_value(
+            marker_dict, self.plot_selected_markers_chooser.get_selected_item(
+            ).get_string())
         config["plot_unselected_markers"] = unselected_marker_value
         config["plot_selected_markers"] = selected_marker_value
         return config

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -1,15 +1,16 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import json
 import os
 import shutil
-import json
-import matplotlib.pyplot as plt
-import matplotlib.font_manager
-import pickle
-from gi.repository import Gtk, Adw
-from matplotlib.lines import Line2D
-from . import plotting_tools, graphs
 
-from . import plotting_tools, graphs, utilities
+from gi.repository import Adw, Gtk
+
+from graphs import utilities
+
+import matplotlib.font_manager
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
 
 class Preferences():
     def __init__(self, parent):
@@ -28,11 +29,11 @@ class Preferences():
             config = utilities.remove_unused_config_keys(config, template)
             config = utilities.add_new_config_keys(config, template)
         return config
-        
+
     def create_new_config_file(self):
         config_path = self.get_config_path()
         if not os.path.isfile(f'{config_path}/config.json'):
-            self.reset_config()    
+            self.reset_config()
             print('New configuration file created')
         else:
             print('Loading configuration file')
@@ -78,8 +79,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
     savefig_filetype_list = Gtk.Template.Child()
     addequation_equation = Gtk.Template.Child()
     addequation_X_start = Gtk.Template.Child()
-    addequation_X_stop = Gtk.Template.Child()    
-    addequation_step_size = Gtk.Template.Child()    
+    addequation_X_stop = Gtk.Template.Child()
+    addequation_step_size = Gtk.Template.Child()
     plot_Y_label = Gtk.Template.Child()
     plot_X_label = Gtk.Template.Child()
     plot_right_label = Gtk.Template.Child()
@@ -124,15 +125,15 @@ class PreferencesWindow(Adw.PreferencesWindow):
     def __init__(self, parent):
         super().__init__()
         self.props.modal = True
-        color_cycles =  [
+        color_cycles = [
             'Pastel1', 'Pastel2', 'Paired', 'Accent',
             'Dark2', 'Set1', 'Set2', 'Set3',
             'tab10', 'tab20', 'tab20b', 'tab20c']
         utilities.populate_chooser(self.plot_color_cycle, color_cycles)
         utilities.populate_chooser(self.plot_style_dark, plt.style.available)
         utilities.populate_chooser(self.plot_style_light, plt.style.available)
-        utilities.populate_chooser(self.plot_selected_markers_chooser, list(Line2D.markers.values()), clear = False)
-        utilities.populate_chooser(self.plot_unselected_markers_chooser, list(Line2D.markers.values()), clear = False)
+        utilities.populate_chooser(self.plot_selected_markers_chooser, list(Line2D.markers.values()), clear=False)
+        utilities.populate_chooser(self.plot_unselected_markers_chooser, list(Line2D.markers.values()), clear=False)
         config = parent.preferences.config
         config = self.load_configuration(config)
         self.connect('close-request', self.on_close, parent)
@@ -153,8 +154,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.plot_unselected_marker_size.set_range(0, 30)
         self.addequation_equation.set_text(str(config['addequation_equation']))
         self.addequation_X_start.set_text(str(config['addequation_X_start']))
-        self.addequation_X_stop.set_text(str(config['addequation_X_stop']))    
-        self.addequation_step_size.set_text(str(config['addequation_step_size']))          
+        self.addequation_X_stop.set_text(str(config['addequation_X_stop']))
+        self.addequation_step_size.set_text(str(config['addequation_step_size']))
         self.import_skip_rows.set_value(int(config['import_skip_rows']))
         self.column_y.set_value(int(config['import_column_y']))
         self.column_x.set_value(int(config['import_column_x']))
@@ -227,7 +228,6 @@ class PreferencesWindow(Adw.PreferencesWindow):
             new_style = font_name[-2]
         return new_style
 
-
     def get_available_fonts(self):
         available_fonts = matplotlib.font_manager.get_font_names()
         font_list = []
@@ -236,7 +236,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         return sorted(font_list)
 
     def set_config(self):
-        config = dict()
+        config = {}
         font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(' ')
         font_size = font_name[-1]
         font_weight = self.get_font_weight(font_name)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -21,10 +21,10 @@ class Preferences():
         self.check_config(self.config)
 
     def check_config(self, config):
-        template_path = os.path.join(os.getenv('XDG_DATA_DIRS'))
-        template_path = template_path.split(':')[0] + '/graphs/graphs'
+        template_path = os.path.join(os.getenv("XDG_DATA_DIRS"))
+        template_path = template_path.split(":")[0] + "/graphs/graphs"
         os.chdir(template_path)
-        with open('config.json', 'r', encoding='utf-8') as file:
+        with open("config.json", "r", encoding="utf-8") as file:
             template = json.load(file)
         if set(config.keys()) != set(template.keys()):
             config = utilities.remove_unused_config_keys(config, template)
@@ -33,26 +33,26 @@ class Preferences():
 
     def create_new_config_file(self):
         config_path = self.get_config_path()
-        if not os.path.isfile(f'{config_path}/config.json'):
+        if not os.path.isfile(f"{config_path}/config.json"):
             self.reset_config()
-            print('New configuration file created')
+            print("New configuration file created")
         else:
-            print('Loading configuration file')
+            print("Loading configuration file")
 
     def reset_config(self):
         config_path = self.get_config_path()
-        old_path = os.path.join(os.getenv('XDG_DATA_DIRS'))
-        old_path = old_path.split(':')[0] + '/graphs/graphs'
+        old_path = os.path.join(os.getenv("XDG_DATA_DIRS"))
+        old_path = old_path.split(":")[0] + "/graphs/graphs"
         if not os.path.isdir(config_path):
             os.mkdir(config_path)
-        path = config_path + '/config.json'
-        shutil.copy(f'{old_path}/config.json', path)
-        print('Loaded new config')
+        path = config_path + "/config.json"
+        shutil.copy(f"{old_path}/config.json", path)
+        print("Loaded new config")
 
     def load_config(self):
         config_path = self.get_config_path()
         os.chdir(config_path)
-        with open('config.json', 'r') as file:
+        with open("config.json", "r") as file:
             config = json.load(file)
         config = self.check_config(config)
         return config
@@ -60,18 +60,18 @@ class Preferences():
     def save_config(self):
         config_path = self.get_config_path()
         os.chdir(config_path)
-        with open('config.json', 'w') as file:
+        with open("config.json", "w") as file:
             json.dump(self.config, file)
 
     def get_config_path(self) -> str:
-        if os.getenv('XDG_CONFIG_HOME'):
-            return os.path.join(os.getenv('XDG_CONFIG_HOME'), 'Graphs')
-        return os.path.join(str(Path.home()), '.local', 'share', 'Graphs')
+        if os.getenv("XDG_CONFIG_HOME"):
+            return os.path.join(os.getenv("XDG_CONFIG_HOME"), "Graphs")
+        return os.path.join(str(Path.home()), ".local", "share", "Graphs")
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/preferences.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/preferences.ui")
 class PreferencesWindow(Adw.PreferencesWindow):
-    __gtype_name__ = 'PreferencesWindow'
+    __gtype_name__ = "PreferencesWindow"
     selected_line_thickness_slider = Gtk.Template.Child()
     unselected_line_thickness_slider = Gtk.Template.Child()
     savefig_transparent_check_button = Gtk.Template.Child()
@@ -126,9 +126,9 @@ class PreferencesWindow(Adw.PreferencesWindow):
         super().__init__()
         self.props.modal = True
         color_cycles = [
-            'Pastel1', 'Pastel2', 'Paired', 'Accent',
-            'Dark2', 'Set1', 'Set2', 'Set3',
-            'tab10', 'tab20', 'tab20b', 'tab20c']
+            "Pastel1", "Pastel2", "Paired", "Accent",
+            "Dark2", "Set1", "Set2", "Set3",
+            "tab10", "tab20", "tab20b", "tab20c"]
         utilities.populate_chooser(self.plot_color_cycle, color_cycles)
         utilities.populate_chooser(self.plot_style_dark, plt.style.available)
         utilities.populate_chooser(self.plot_style_light, plt.style.available)
@@ -136,11 +136,11 @@ class PreferencesWindow(Adw.PreferencesWindow):
         utilities.populate_chooser(self.plot_unselected_markers_chooser, list(Line2D.markers.values()), clear=False)
         config = parent.preferences.config
         config = self.load_configuration(config)
-        self.connect('close-request', self.on_close, parent)
+        self.connect("close-request", self.on_close, parent)
         self.set_transient_for(parent.main_window)
 
     def load_configuration(self, config):
-        font_string = config['plot_font_string']
+        font_string = config["plot_font_string"]
         font_desc = self.plot_font_chooser.get_font_desc().from_string(font_string)
         self.plot_font_chooser.set_font_desc(font_desc)
         self.plot_font_chooser.set_use_font(True)
@@ -152,79 +152,79 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.plot_minor_tick_length.set_range(0, 20)
         self.plot_selected_marker_size.set_range(0, 30)
         self.plot_unselected_marker_size.set_range(0, 30)
-        self.addequation_equation.set_text(str(config['addequation_equation']))
-        self.addequation_X_start.set_text(str(config['addequation_X_start']))
-        self.addequation_X_stop.set_text(str(config['addequation_X_stop']))
-        self.addequation_step_size.set_text(str(config['addequation_step_size']))
-        self.import_skip_rows.set_value(int(config['import_skip_rows']))
-        self.column_y.set_value(int(config['import_column_y']))
-        self.column_x.set_value(int(config['import_column_x']))
-        self.import_delimiter.set_text(config['import_delimiter'])
-        self.plot_selected_marker_size.set_value(config['plot_selected_marker_size'])
-        self.plot_unselected_marker_size.set_value(config['plot_unselected_marker_size'])
-        self.unselected_line_thickness_slider.set_value(config['unselected_linewidth'])
-        self.selected_line_thickness_slider.set_value(config['selected_linewidth'])
-        self.plot_minor_tick_width.set_value(config['plot_minor_tick_width'])
-        self.plot_major_tick_width.set_value(config['plot_major_tick_width'])
-        self.plot_minor_tick_length.set_value(config['plot_minor_tick_length'])
-        self.plot_major_tick_length.set_value(config['plot_major_tick_length'])
-        self.plot_Y_label.set_text(config['plot_Y_label'])
-        self.plot_X_label.set_text(config['plot_X_label'])
-        self.plot_right_label.set_text(config['plot_right_label'])
-        self.plot_top_label.set_text(config['plot_top_label'])
-        self.plot_title.set_text(config['plot_title'])
-        utilities.set_chooser(self.savefig_filetype_chooser, config['savefig_filetype'])
-        utilities.set_chooser(self.center_data_chooser, config['action_center_data'])
-        utilities.set_chooser(self.plot_X_scale, config['plot_X_scale'])
-        utilities.set_chooser(self.plot_top_scale, config['plot_top_scale'])
-        utilities.set_chooser(self.plot_right_scale, config['plot_right_scale'])
-        utilities.set_chooser(self.plot_Y_scale, config['plot_Y_scale'])
-        utilities.set_chooser(self.plot_X_position, config['plot_X_position'])
-        utilities.set_chooser(self.plot_Y_position, config['plot_Y_position'])
-        utilities.set_chooser(self.plot_tick_direction, config['plot_tick_direction'])
-        utilities.set_chooser(self.handle_duplicates_chooser, config['handle_duplicates'])
-        utilities.set_chooser(self.import_separator, config['import_separator'])
-        utilities.set_chooser(self.plot_color_cycle, config['plot_color_cycle'])
-        utilities.set_chooser(self.plot_selected_linestyle_chooser, config['plot_selected_linestyle'])
-        utilities.set_chooser(self.plot_unselected_linestyle_chooser, config['plot_unselected_linestyle'])
-        utilities.set_chooser(self.plot_style_light, config['plot_style_light'])
-        utilities.set_chooser(self.plot_style_dark, config['plot_style_dark'])
+        self.addequation_equation.set_text(str(config["addequation_equation"]))
+        self.addequation_X_start.set_text(str(config["addequation_X_start"]))
+        self.addequation_X_stop.set_text(str(config["addequation_X_stop"]))
+        self.addequation_step_size.set_text(str(config["addequation_step_size"]))
+        self.import_skip_rows.set_value(int(config["import_skip_rows"]))
+        self.column_y.set_value(int(config["import_column_y"]))
+        self.column_x.set_value(int(config["import_column_x"]))
+        self.import_delimiter.set_text(config["import_delimiter"])
+        self.plot_selected_marker_size.set_value(config["plot_selected_marker_size"])
+        self.plot_unselected_marker_size.set_value(config["plot_unselected_marker_size"])
+        self.unselected_line_thickness_slider.set_value(config["unselected_linewidth"])
+        self.selected_line_thickness_slider.set_value(config["selected_linewidth"])
+        self.plot_minor_tick_width.set_value(config["plot_minor_tick_width"])
+        self.plot_major_tick_width.set_value(config["plot_major_tick_width"])
+        self.plot_minor_tick_length.set_value(config["plot_minor_tick_length"])
+        self.plot_major_tick_length.set_value(config["plot_major_tick_length"])
+        self.plot_Y_label.set_text(config["plot_Y_label"])
+        self.plot_X_label.set_text(config["plot_X_label"])
+        self.plot_right_label.set_text(config["plot_right_label"])
+        self.plot_top_label.set_text(config["plot_top_label"])
+        self.plot_title.set_text(config["plot_title"])
+        utilities.set_chooser(self.savefig_filetype_chooser, config["savefig_filetype"])
+        utilities.set_chooser(self.center_data_chooser, config["action_center_data"])
+        utilities.set_chooser(self.plot_X_scale, config["plot_X_scale"])
+        utilities.set_chooser(self.plot_top_scale, config["plot_top_scale"])
+        utilities.set_chooser(self.plot_right_scale, config["plot_right_scale"])
+        utilities.set_chooser(self.plot_Y_scale, config["plot_Y_scale"])
+        utilities.set_chooser(self.plot_X_position, config["plot_X_position"])
+        utilities.set_chooser(self.plot_Y_position, config["plot_Y_position"])
+        utilities.set_chooser(self.plot_tick_direction, config["plot_tick_direction"])
+        utilities.set_chooser(self.handle_duplicates_chooser, config["handle_duplicates"])
+        utilities.set_chooser(self.import_separator, config["import_separator"])
+        utilities.set_chooser(self.plot_color_cycle, config["plot_color_cycle"])
+        utilities.set_chooser(self.plot_selected_linestyle_chooser, config["plot_selected_linestyle"])
+        utilities.set_chooser(self.plot_unselected_linestyle_chooser, config["plot_unselected_linestyle"])
+        utilities.set_chooser(self.plot_style_light, config["plot_style_light"])
+        utilities.set_chooser(self.plot_style_dark, config["plot_style_dark"])
         marker_dict = Line2D.markers
-        unselected_marker_value = marker_dict[config['plot_unselected_markers']]
-        selected_marker_value = marker_dict[config['plot_selected_markers']]
+        unselected_marker_value = marker_dict[config["plot_unselected_markers"]]
+        selected_marker_value = marker_dict[config["plot_selected_markers"]]
         utilities.set_chooser(self.plot_selected_markers_chooser, selected_marker_value)
         utilities.set_chooser(self.plot_unselected_markers_chooser, unselected_marker_value)
-        if config['plot_tick_left']:
+        if config["plot_tick_left"]:
             self.plot_tick_left.set_active(True)
-        if config['plot_tick_right']:
+        if config["plot_tick_right"]:
             self.plot_tick_right.set_active(True)
-        if config['plot_tick_bottom']:
+        if config["plot_tick_bottom"]:
             self.plot_tick_bottom.set_active(True)
-        if config['plot_tick_top']:
+        if config["plot_tick_top"]:
             self.plot_tick_top.set_active(True)
-        if config['guess_headers']:
+        if config["guess_headers"]:
             self.guess_headers.set_active(True)
-        if config['savefig_transparent']:
+        if config["savefig_transparent"]:
             self.savefig_transparent_check_button.set_active(True)
-        if config['plot_legend']:
+        if config["plot_legend"]:
             self.plot_legend_check.set_active(True)
-        if config['plot_invert_color_cycle_dark']:
+        if config["plot_invert_color_cycle_dark"]:
             self.plot_invert_color_cycle_dark.set_active(True)
         return config
 
     def get_font_weight(self, font_name):
-        valid_weights = ['normal', 'bold', 'heavy', 'light', 'ultrabold', 'ultralight']
-        if font_name[-2] != 'italic':
+        valid_weights = ["normal", "bold", "heavy", "light", "ultrabold", "ultralight"]
+        if font_name[-2] != "italic":
             new_weight = font_name[-2]
         else:
             new_weight = font_name[-3]
         if new_weight not in valid_weights:
-            new_weight = 'normal'
+            new_weight = "normal"
         return new_weight
 
     def get_font_style(self, font_name):
-        new_style = 'normal'
-        if font_name[-2] == ('italic' or 'oblique' or 'normal'):
+        new_style = "normal"
+        if font_name[-2] == ("italic" or "oblique" or "normal"):
             new_style = font_name[-2]
         return new_style
 
@@ -237,67 +237,67 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     def set_config(self):
         config = {}
-        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(' ')
+        font_name = self.plot_font_chooser.get_font_desc().to_string().lower().split(" ")
         font_size = font_name[-1]
         font_weight = self.get_font_weight(font_name)
         font_style = self.get_font_style(font_name)
-        config['addequation_equation'] = self.addequation_equation.get_text()
-        config['addequation_X_start'] = self.addequation_X_start.get_text()
-        config['addequation_X_stop'] = self.addequation_X_stop.get_text()
-        config['addequation_step_size'] = self.addequation_step_size.get_text()
-        config['plot_font_string'] = self.plot_font_chooser.get_font_desc().to_string()
-        config['plot_selected_marker_size'] = self.plot_selected_marker_size.get_value()
-        config['plot_unselected_marker_size'] = self.plot_unselected_marker_size.get_value()
-        config['selected_linewidth'] = self.selected_line_thickness_slider.get_value()
-        config['unselected_linewidth'] = self.unselected_line_thickness_slider.get_value()
-        config['plot_major_tick_width'] = self.plot_major_tick_width.get_value()
-        config['plot_minor_tick_width'] = self.plot_minor_tick_width.get_value()
-        config['plot_major_tick_length'] = self.plot_major_tick_length.get_value()
-        config['plot_minor_tick_length'] = self.plot_minor_tick_length.get_value()
-        config['plot_tick_left'] = self.plot_tick_left.get_active()
-        config['plot_tick_right'] = self.plot_tick_right.get_active()
-        config['plot_tick_top'] = self.plot_tick_top.get_active()
-        config['plot_tick_bottom'] = self.plot_tick_bottom.get_active()
-        config['plot_tick_direction'] = self.plot_tick_direction.get_selected_item().get_string()
-        config['guess_headers'] = self.guess_headers.get_active()
-        config['handle_duplicates'] = self.handle_duplicates_chooser.get_selected_item().get_string()
-        config['savefig_transparent'] = self.savefig_transparent_check_button.get_active()
-        config['plot_legend'] = self.plot_legend_check.get_active()
-        config['plot_invert_color_cycle_dark'] = self.plot_invert_color_cycle_dark.get_active()
-        config['plot_Y_label'] = self.plot_Y_label.get_text()
-        config['plot_X_label'] = self.plot_X_label.get_text()
-        config['plot_right_label'] = self.plot_right_label.get_text()
-        config['plot_top_label'] = self.plot_top_label.get_text()
-        config['plot_font_size'] = font_size
-        config['plot_font_style'] = font_style
-        config['plot_font_weight'] = font_weight
-        config['plot_font_family'] = self.plot_font_chooser.get_font_desc().get_family()
-        config['plot_title'] = self.plot_title.get_text()
-        config['savefig_filetype'] = self.savefig_filetype_chooser.get_selected_item().get_string()
-        config['plot_color_cycle'] = self.plot_color_cycle.get_selected_item().get_string()
-        config['plot_X_scale'] = self.plot_X_scale.get_selected_item().get_string()
-        config['plot_Y_scale'] = self.plot_Y_scale.get_selected_item().get_string()
-        config['plot_top_scale'] = self.plot_top_scale.get_selected_item().get_string()
-        config['plot_right_scale'] = self.plot_right_scale.get_selected_item().get_string()
-        config['plot_right_scale'] = self.plot_right_scale.get_selected_item().get_string()
-        config['plot_top_scale'] = self.plot_top_scale.get_selected_item().get_string()
-        config['plot_X_position'] = self.plot_X_position.get_selected_item().get_string()
-        config['plot_Y_position'] = self.plot_Y_position.get_selected_item().get_string()
-        config['action_center_data'] = self.center_data_chooser.get_selected_item().get_string()
-        config['plot_selected_linestyle'] = self.plot_selected_linestyle_chooser.get_selected_item().get_string()
-        config['plot_unselected_linestyle'] = self.plot_unselected_linestyle_chooser.get_selected_item().get_string()
-        config['plot_style_dark'] = self.plot_style_dark.get_selected_item().get_string()
-        config['plot_style_light'] = self.plot_style_light.get_selected_item().get_string()
-        config['import_column_x'] = int(self.column_x.get_value())
-        config['import_column_y'] = int(self.column_y.get_value())
-        config['import_skip_rows'] = int(self.import_skip_rows.get_value())
-        config['import_separator'] = self.import_separator.get_selected_item().get_string()
-        config['import_delimiter'] = self.import_delimiter.get_text()
+        config["addequation_equation"] = self.addequation_equation.get_text()
+        config["addequation_X_start"] = self.addequation_X_start.get_text()
+        config["addequation_X_stop"] = self.addequation_X_stop.get_text()
+        config["addequation_step_size"] = self.addequation_step_size.get_text()
+        config["plot_font_string"] = self.plot_font_chooser.get_font_desc().to_string()
+        config["plot_selected_marker_size"] = self.plot_selected_marker_size.get_value()
+        config["plot_unselected_marker_size"] = self.plot_unselected_marker_size.get_value()
+        config["selected_linewidth"] = self.selected_line_thickness_slider.get_value()
+        config["unselected_linewidth"] = self.unselected_line_thickness_slider.get_value()
+        config["plot_major_tick_width"] = self.plot_major_tick_width.get_value()
+        config["plot_minor_tick_width"] = self.plot_minor_tick_width.get_value()
+        config["plot_major_tick_length"] = self.plot_major_tick_length.get_value()
+        config["plot_minor_tick_length"] = self.plot_minor_tick_length.get_value()
+        config["plot_tick_left"] = self.plot_tick_left.get_active()
+        config["plot_tick_right"] = self.plot_tick_right.get_active()
+        config["plot_tick_top"] = self.plot_tick_top.get_active()
+        config["plot_tick_bottom"] = self.plot_tick_bottom.get_active()
+        config["plot_tick_direction"] = self.plot_tick_direction.get_selected_item().get_string()
+        config["guess_headers"] = self.guess_headers.get_active()
+        config["handle_duplicates"] = self.handle_duplicates_chooser.get_selected_item().get_string()
+        config["savefig_transparent"] = self.savefig_transparent_check_button.get_active()
+        config["plot_legend"] = self.plot_legend_check.get_active()
+        config["plot_invert_color_cycle_dark"] = self.plot_invert_color_cycle_dark.get_active()
+        config["plot_Y_label"] = self.plot_Y_label.get_text()
+        config["plot_X_label"] = self.plot_X_label.get_text()
+        config["plot_right_label"] = self.plot_right_label.get_text()
+        config["plot_top_label"] = self.plot_top_label.get_text()
+        config["plot_font_size"] = font_size
+        config["plot_font_style"] = font_style
+        config["plot_font_weight"] = font_weight
+        config["plot_font_family"] = self.plot_font_chooser.get_font_desc().get_family()
+        config["plot_title"] = self.plot_title.get_text()
+        config["savefig_filetype"] = self.savefig_filetype_chooser.get_selected_item().get_string()
+        config["plot_color_cycle"] = self.plot_color_cycle.get_selected_item().get_string()
+        config["plot_X_scale"] = self.plot_X_scale.get_selected_item().get_string()
+        config["plot_Y_scale"] = self.plot_Y_scale.get_selected_item().get_string()
+        config["plot_top_scale"] = self.plot_top_scale.get_selected_item().get_string()
+        config["plot_right_scale"] = self.plot_right_scale.get_selected_item().get_string()
+        config["plot_right_scale"] = self.plot_right_scale.get_selected_item().get_string()
+        config["plot_top_scale"] = self.plot_top_scale.get_selected_item().get_string()
+        config["plot_X_position"] = self.plot_X_position.get_selected_item().get_string()
+        config["plot_Y_position"] = self.plot_Y_position.get_selected_item().get_string()
+        config["action_center_data"] = self.center_data_chooser.get_selected_item().get_string()
+        config["plot_selected_linestyle"] = self.plot_selected_linestyle_chooser.get_selected_item().get_string()
+        config["plot_unselected_linestyle"] = self.plot_unselected_linestyle_chooser.get_selected_item().get_string()
+        config["plot_style_dark"] = self.plot_style_dark.get_selected_item().get_string()
+        config["plot_style_light"] = self.plot_style_light.get_selected_item().get_string()
+        config["import_column_x"] = int(self.column_x.get_value())
+        config["import_column_y"] = int(self.column_y.get_value())
+        config["import_skip_rows"] = int(self.import_skip_rows.get_value())
+        config["import_separator"] = self.import_separator.get_selected_item().get_string()
+        config["import_delimiter"] = self.import_delimiter.get_text()
         marker_dict = Line2D.markers
         unselected_marker_value = utilities.get_dict_by_value(marker_dict, self.plot_unselected_markers_chooser.get_selected_item().get_string())
         selected_marker_value = utilities.get_dict_by_value(marker_dict, self.plot_selected_markers_chooser.get_selected_item().get_string())
-        config['plot_unselected_markers'] = unselected_marker_value
-        config['plot_selected_markers'] = selected_marker_value
+        config["plot_unselected_markers"] = unselected_marker_value
+        config["plot_selected_markers"] = selected_marker_value
         return config
 
     def on_close(self, _, parent):

--- a/src/rename_label.py
+++ b/src/rename_label.py
@@ -33,7 +33,8 @@ class RenameLabelWindow(Adw.Window):
         if axis == parent.canvas.title:
             self.set_title("Rename Title")
             self.preferencegroup.set_title("Change Title")
-            self.preferencegroup.set_description("Here you can change the title of the plot")
+            self.preferencegroup.set_description(
+                "Here you can change the title of the plot")
             self.label_entry.set_title("Title")
         self.label_entry.set_text(axis.get_text())
 

--- a/src/rename_label.py
+++ b/src/rename_label.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Gtk, Adw
+from gi.repository import Adw, Gtk
 
-from . import plotting_tools
+from graphs import plotting_tools
+
 
 def open_rename_label_window(self, axis):
     win = RenameLabelWindow(self, axis)
@@ -11,10 +12,12 @@ def open_rename_label_window(self, axis):
     button.connect('clicked', on_accept, self, win, axis)
     win.present()
 
+
 def on_accept(widget, self, window, axis):
     window.rename(self, axis)
     plotting_tools.reload_plot(self)
     window.destroy()
+
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/rename_label_window.ui')
 class RenameLabelWindow(Adw.Window):
@@ -33,10 +36,10 @@ class RenameLabelWindow(Adw.Window):
             self.preferencegroup.set_description('Here you can change the title of the plot')
             self.label_entry.set_title('Title')
         self.load_settings(parent, axis)
-    
+
     def load_settings(self, parent, axis):
         self.label_entry.set_text(axis.get_text())
-        
+
     def rename(self, parent, axis):
         if axis == parent.canvas.top_label:
             parent.plot_settings.top_label = self.label_entry.get_text()

--- a/src/rename_label.py
+++ b/src/rename_label.py
@@ -8,7 +8,7 @@ def open_rename_label_window(self, axis):
     win.set_transient_for(self.main_window)
     win.set_modal(True)
     button = win.rename_label_confirm_button
-    button.connect("clicked", on_accept, self, win, axis)
+    button.connect('clicked', on_accept, self, win, axis)
     win.present()
 
 def on_accept(widget, self, window, axis):
@@ -16,9 +16,9 @@ def on_accept(widget, self, window, axis):
     plotting_tools.reload_plot(self)
     window.destroy()
 
-@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/rename_label_window.ui")
+@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/rename_label_window.ui')
 class RenameLabelWindow(Adw.Window):
-    __gtype_name__ = "RenameLabelWindow"
+    __gtype_name__ = 'RenameLabelWindow'
     rename_label_confirm_button = Gtk.Template.Child()
     label_entry = Gtk.Template.Child()
     preferencegroup = Gtk.Template.Child()
@@ -26,12 +26,12 @@ class RenameLabelWindow(Adw.Window):
     def __init__(self, parent, axis):
         super().__init__()
         style_context = self.rename_label_confirm_button.get_style_context()
-        style_context.add_class("suggested-action")
+        style_context.add_class('suggested-action')
         if axis == parent.canvas.title:
-            self.set_title("Rename Title")
-            self.preferencegroup.set_title("Change Title")
-            self.preferencegroup.set_description("Here you can change the title of the plot")
-            self.label_entry.set_title("Title")
+            self.set_title('Rename Title')
+            self.preferencegroup.set_title('Change Title')
+            self.preferencegroup.set_description('Here you can change the title of the plot')
+            self.label_entry.set_title('Title')
         self.load_settings(parent, axis)
     
     def load_settings(self, parent, axis):

--- a/src/rename_label.py
+++ b/src/rename_label.py
@@ -9,7 +9,7 @@ def open_rename_label_window(self, axis):
     win.set_transient_for(self.main_window)
     win.set_modal(True)
     button = win.rename_label_confirm_button
-    button.connect('clicked', on_accept, self, win, axis)
+    button.connect("clicked", on_accept, self, win, axis)
     win.present()
 
 
@@ -19,9 +19,9 @@ def on_accept(_widget, self, window, axis):
     window.destroy()
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/rename_label_window.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/rename_label_window.ui")
 class RenameLabelWindow(Adw.Window):
-    __gtype_name__ = 'RenameLabelWindow'
+    __gtype_name__ = "RenameLabelWindow"
     rename_label_confirm_button = Gtk.Template.Child()
     label_entry = Gtk.Template.Child()
     preferencegroup = Gtk.Template.Child()
@@ -29,12 +29,12 @@ class RenameLabelWindow(Adw.Window):
     def __init__(self, parent, axis):
         super().__init__()
         style_context = self.rename_label_confirm_button.get_style_context()
-        style_context.add_class('suggested-action')
+        style_context.add_class("suggested-action")
         if axis == parent.canvas.title:
-            self.set_title('Rename Title')
-            self.preferencegroup.set_title('Change Title')
-            self.preferencegroup.set_description('Here you can change the title of the plot')
-            self.label_entry.set_title('Title')
+            self.set_title("Rename Title")
+            self.preferencegroup.set_title("Change Title")
+            self.preferencegroup.set_description("Here you can change the title of the plot")
+            self.label_entry.set_title("Title")
         self.label_entry.set_text(axis.get_text())
 
     def rename(self, parent, axis):

--- a/src/rename_label.py
+++ b/src/rename_label.py
@@ -13,7 +13,7 @@ def open_rename_label_window(self, axis):
     win.present()
 
 
-def on_accept(widget, self, window, axis):
+def on_accept(_widget, self, window, axis):
     window.rename(self, axis)
     plotting_tools.reload_plot(self)
     window.destroy()
@@ -35,9 +35,6 @@ class RenameLabelWindow(Adw.Window):
             self.preferencegroup.set_title('Change Title')
             self.preferencegroup.set_description('Here you can change the title of the plot')
             self.label_entry.set_title('Title')
-        self.load_settings(parent, axis)
-
-    def load_settings(self, parent, axis):
         self.label_entry.set_text(axis.get_text())
 
     def rename(self, parent, axis):

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -3,14 +3,15 @@ import time
 
 from gi.repository import Gtk
 
-from graphs import colorpicker, graphs, plot_settings, plotting_tools, ui, utilities
+from graphs import colorpicker, graphs, plotting_tools, ui, utilities
+from graphs.plot_settings import PlotSettingsWindow
 
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/sample_box.ui')
 class SampleBox(Gtk.Box):
     __gtype_name__ = 'SampleBox'
     sample_box = Gtk.Template.Child()
-    sample_ID_label = Gtk.Template.Child()
+    sample_id_label = Gtk.Template.Child()
     check_button = Gtk.Template.Child()
     delete_button = Gtk.Template.Child()
 
@@ -21,7 +22,7 @@ class SampleBox(Gtk.Box):
             label = f'{label[:max_length]}...'
         if selected:
             self.check_button.set_active(True)
-        self.sample_ID_label.set_text(label)
+        self.sample_id_label.set_text(label)
         self.key = key
         self.parent = parent
         self.one_click_trigger = False
@@ -32,7 +33,7 @@ class SampleBox(Gtk.Box):
         self.gesture.connect('released', self.clicked, parent)
         self.delete_button.connect('clicked', self.delete)
         self.color_picker = colorpicker.ColorPicker(color, key, parent)
-        self.sample_box.insert_child_after(self.color_picker, self.sample_ID_label)
+        self.sample_box.insert_child_after(self.color_picker, self.sample_id_label)
         self.check_button.connect('toggled', self.toggled)
 
     def delete(self, _):
@@ -54,4 +55,5 @@ class SampleBox(Gtk.Box):
             else:
                 self.one_click_trigger = False
                 self.time_first_click = 0
-                plot_settings.open_plot_settings(None, None, graph, self.key)
+                win = PlotSettingsWindow(self.parent, self.key)
+                win.present()

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -7,7 +7,7 @@ from . import graphs, plot_settings, colorpicker, plotting_tools, ui, utilities
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/sample_box.ui')
 class SampleBox(Gtk.Box):
-    __gtype_name__ = "SampleBox"
+    __gtype_name__ = 'SampleBox'
     sample_box = Gtk.Template.Child()
     sample_ID_label = Gtk.Template.Child()
     check_button = Gtk.Template.Child()
@@ -17,7 +17,7 @@ class SampleBox(Gtk.Box):
         super().__init__()
         max_length = int(26)
         if len(label) > max_length:
-            label = f"{label[:max_length]}..."
+            label = f'{label[:max_length]}...'
         if selected:
             self.check_button.set_active(True)
         self.sample_ID_label.set_text(label)
@@ -28,11 +28,11 @@ class SampleBox(Gtk.Box):
         self.gesture = Gtk.GestureClick()
         self.gesture.set_button(0)
         self.add_controller(self.gesture)
-        self.gesture.connect("released", self.clicked, parent)
-        self.delete_button.connect("clicked", self.delete)
+        self.gesture.connect('released', self.clicked, parent)
+        self.delete_button.connect('clicked', self.delete)
         self.color_picker = colorpicker.ColorPicker(color, key, parent)
         self.sample_box.insert_child_after(self.color_picker, self.sample_ID_label)
-        self.check_button.connect("toggled", self.toggled)
+        self.check_button.connect('toggled', self.toggled)
 
     def delete(self, _):
         graphs.delete(self.parent, self.key, True)

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -33,7 +33,8 @@ class SampleBox(Gtk.Box):
         self.gesture.connect("released", self.clicked, parent)
         self.delete_button.connect("clicked", self.delete)
         self.color_picker = colorpicker.ColorPicker(color, key, parent)
-        self.sample_box.insert_child_after(self.color_picker, self.sample_id_label)
+        self.sample_box.insert_child_after(
+            self.color_picker, self.sample_id_label)
         self.check_button.connect("toggled", self.toggled)
 
     def delete(self, _):
@@ -41,9 +42,10 @@ class SampleBox(Gtk.Box):
 
     def toggled(self, _):
         plotting_tools.refresh_plot(self.parent)
-        ui.enable_data_dependent_buttons(self.parent, utilities.get_selected_keys(self.parent))
+        ui.enable_data_dependent_buttons(
+            self.parent, utilities.get_selected_keys(self.parent))
 
-    def clicked(self, _gesture, _, _xpos, _ypos, graph):
+    def clicked(self, _gesture, _, _xpos, _ypos, _graph):
         if not self.one_click_trigger:
             self.one_click_trigger = True
             self.time_first_click = time.time()

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -7,9 +7,9 @@ from graphs import colorpicker, graphs, plotting_tools, ui, utilities
 from graphs.plot_settings import PlotSettingsWindow
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/sample_box.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/sample_box.ui")
 class SampleBox(Gtk.Box):
-    __gtype_name__ = 'SampleBox'
+    __gtype_name__ = "SampleBox"
     sample_box = Gtk.Template.Child()
     sample_id_label = Gtk.Template.Child()
     check_button = Gtk.Template.Child()
@@ -19,7 +19,7 @@ class SampleBox(Gtk.Box):
         super().__init__()
         max_length = int(26)
         if len(label) > max_length:
-            label = f'{label[:max_length]}...'
+            label = f"{label[:max_length]}..."
         if selected:
             self.check_button.set_active(True)
         self.sample_id_label.set_text(label)
@@ -30,11 +30,11 @@ class SampleBox(Gtk.Box):
         self.gesture = Gtk.GestureClick()
         self.gesture.set_button(0)
         self.add_controller(self.gesture)
-        self.gesture.connect('released', self.clicked, parent)
-        self.delete_button.connect('clicked', self.delete)
+        self.gesture.connect("released", self.clicked, parent)
+        self.delete_button.connect("clicked", self.delete)
         self.color_picker = colorpicker.ColorPicker(color, key, parent)
         self.sample_box.insert_child_after(self.color_picker, self.sample_id_label)
-        self.check_button.connect('toggled', self.toggled)
+        self.check_button.connect("toggled", self.toggled)
 
     def delete(self, _):
         graphs.delete(self.parent, self.key, True)

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -42,7 +42,7 @@ class SampleBox(Gtk.Box):
         plotting_tools.refresh_plot(self.parent)
         ui.enable_data_dependent_buttons(self.parent, utilities.get_selected_keys(self.parent))
 
-    def clicked(self, gesture, _, xpos, ypos, graphs):
+    def clicked(self, _gesture, _, _xpos, _ypos, graph):
         if not self.one_click_trigger:
             self.one_click_trigger = True
             self.time_first_click = time.time()
@@ -54,4 +54,4 @@ class SampleBox(Gtk.Box):
             else:
                 self.one_click_trigger = False
                 self.time_first_click = 0
-                plot_settings.open_plot_settings(None, None, graphs, self.key)
+                plot_settings.open_plot_settings(None, None, graph, self.key)

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import time
 
-from gi.repository import Gtk, Adw
+from gi.repository import Gtk
 
-from . import graphs, plot_settings, colorpicker, plotting_tools, ui, utilities
+from graphs import colorpicker, graphs, plot_settings, plotting_tools, ui, utilities
+
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/sample_box.ui')
 class SampleBox(Gtk.Box):
@@ -12,8 +13,8 @@ class SampleBox(Gtk.Box):
     sample_ID_label = Gtk.Template.Child()
     check_button = Gtk.Template.Child()
     delete_button = Gtk.Template.Child()
-    
-    def __init__(self, parent, key, color, label, selected = False):
+
+    def __init__(self, parent, key, color, label, selected=False):
         super().__init__()
         max_length = int(26)
         if len(label) > max_length:
@@ -24,7 +25,7 @@ class SampleBox(Gtk.Box):
         self.key = key
         self.parent = parent
         self.one_click_trigger = False
-        self.time_first_click  = 0        
+        self.time_first_click = 0
         self.gesture = Gtk.GestureClick()
         self.gesture.set_button(0)
         self.add_controller(self.gesture)
@@ -42,8 +43,7 @@ class SampleBox(Gtk.Box):
         ui.enable_data_dependent_buttons(self.parent, utilities.get_selected_keys(self.parent))
 
     def clicked(self, gesture, _, xpos, ypos, graphs):
-        double_click = False
-        if self.one_click_trigger == False:
+        if not self.one_click_trigger:
             self.one_click_trigger = True
             self.time_first_click = time.time()
         else:
@@ -53,7 +53,5 @@ class SampleBox(Gtk.Box):
                 self.time_first_click = time.time()
             else:
                 self.one_click_trigger = False
-                self.time_first_click = 0 
-                double_click = True
+                self.time_first_click = 0
                 plot_settings.open_plot_settings(None, None, graphs, self.key)
-                

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -13,8 +13,8 @@ def on_accept(widget, self, window):
         selection, start_stop = item_operations.select_data(self)
 
     for key in selected_keys:
-        if f"{key}_selected" in self.datadict:
-            selected_item = self.datadict[f"{key}_selected"]
+        if f'{key}_selected' in self.datadict:
+            selected_item = self.datadict[f'{key}_selected']
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             xdata_in = self.datadict[key].xdata[start_index:stop_index]
             ydata_in = self.datadict[key].ydata[start_index:stop_index]
@@ -23,7 +23,7 @@ def on_accept(widget, self, window):
             except Exception as e:
                 exception_type = e.__class__.__name__
                 win = self.main_window
-                win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do transformation, make sure the syntax is correct"))
+                win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do transformation, make sure the syntax is correct'))
                 return
             self.datadict[key].xdata[start_index:stop_index] = xdata_out
             self.datadict[key].ydata[start_index:stop_index] = ydata_out
@@ -35,7 +35,7 @@ def on_accept(widget, self, window):
             except Exception as e:
                 exception_type = e.__class__.__name__
                 win = self.main_window
-                win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do transformation, make sure the syntax is correct"))
+                win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do transformation, make sure the syntax is correct'))
                 return
             self.datadict[key].xdata = xdata_out
             self.datadict[key].ydata = ydata_out
@@ -52,13 +52,13 @@ def operation(key, xdata, ydata, input_x, input_y):
     X_range = ydata
     operations = []
     for xy_operation in [input_x, input_y]:
-        xy_operation = xy_operation.replace("Y_range", "y_range")
-        xy_operation = xy_operation.replace("X_range", "x_range")
-        xy_operation = xy_operation.replace("Y", "ydata[index]")
-        xy_operation = xy_operation.replace("X", "xdata[index]")
-        xy_operation = xy_operation.replace("y_range", "Y_range")
-        xy_operation = xy_operation.replace("x_range", "X_range")
-        xy_operation = xy_operation.replace("^", "**")
+        xy_operation = xy_operation.replace('Y_range', 'y_range')
+        xy_operation = xy_operation.replace('X_range', 'x_range')
+        xy_operation = xy_operation.replace('Y', 'ydata[index]')
+        xy_operation = xy_operation.replace('X', 'xdata[index]')
+        xy_operation = xy_operation.replace('y_range', 'Y_range')
+        xy_operation = xy_operation.replace('x_range', 'X_range')
+        xy_operation = xy_operation.replace('^', '**')
         operations.append(xy_operation)
     x_operation, y_operation = operations[0], operations[1]
     for index, value in enumerate(xdata):
@@ -66,9 +66,9 @@ def operation(key, xdata, ydata, input_x, input_y):
         y_array.append(eval(y_operation))
     return x_array, y_array
 
-@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/transform_window.ui")
+@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/transform_window.ui')
 class TransformWindow(Adw.Window):
-    __gtype_name__ = "TransformWindow"
+    __gtype_name__ = 'TransformWindow'
     transform_x_entry = Gtk.Template.Child()
     transform_y_entry = Gtk.Template.Child()
     transform_confirm_button = Gtk.Template.Child()
@@ -76,11 +76,11 @@ class TransformWindow(Adw.Window):
     def __init__(self, parent):
         super().__init__()
         style_context = self.transform_confirm_button.get_style_context()
-        style_context.add_class("suggested-action")
+        style_context.add_class('suggested-action')
 
-        self.transform_x_entry.set_text("X")
-        self.transform_y_entry.set_text("Y")
-        self.transform_confirm_button.connect("clicked", on_accept, parent, self)
+        self.transform_x_entry.set_text('X')
+        self.transform_y_entry.set_text('Y')
+        self.transform_confirm_button.connect('clicked', on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)
     

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Gtk, Adw
+from gi.repository import Adw, Gtk
+
+from graphs import item_operations, plotting_tools, utilities
+from graphs.misc import InteractionMode
+
 from numpy import *
 
-from . import item_operations, plotting_tools, utilities
-from .misc import InteractionMode
 
 def on_accept(widget, self, window):
     input_x = str(window.transform_x_entry.get_text())
@@ -14,7 +16,6 @@ def on_accept(widget, self, window):
 
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
-            selected_item = self.datadict[f'{key}_selected']
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             xdata_in = self.datadict[key].xdata[start_index:stop_index]
             ydata_in = self.datadict[key].ydata[start_index:stop_index]
@@ -45,11 +46,10 @@ def on_accept(widget, self, window):
     plotting_tools.refresh_plot(self)
     window.destroy()
 
+
 def operation(key, xdata, ydata, input_x, input_y):
     x_array = []
     y_array = []
-    Y_range = xdata
-    X_range = ydata
     operations = []
     for xy_operation in [input_x, input_y]:
         xy_operation = xy_operation.replace('Y_range', 'y_range')
@@ -65,6 +65,7 @@ def operation(key, xdata, ydata, input_x, input_y):
         x_array.append(eval(x_operation))
         y_array.append(eval(y_operation))
     return x_array, y_array
+
 
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/transform_window.ui')
 class TransformWindow(Adw.Window):
@@ -83,4 +84,3 @@ class TransformWindow(Adw.Window):
         self.transform_confirm_button.connect('clicked', on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)
-    

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -7,12 +7,12 @@ from graphs.misc import InteractionMode
 from numpy import *
 
 
-def on_accept(widget, self, window):
+def on_accept(_widget, self, window):
     input_x = str(window.transform_x_entry.get_text())
     input_y = str(window.transform_y_entry.get_text())
     selected_keys = utilities.get_selected_keys(self)
-    if self._mode == InteractionMode.SELECT:
-        selection, start_stop = item_operations.select_data(self)
+    if self.interaction_mode == InteractionMode.SELECT:
+        _selection, start_stop = item_operations.select_data(self)
 
     for key in selected_keys:
         if f'{key}_selected' in self.datadict:
@@ -20,7 +20,7 @@ def on_accept(widget, self, window):
             xdata_in = self.datadict[key].xdata[start_index:stop_index]
             ydata_in = self.datadict[key].ydata[start_index:stop_index]
             try:
-                xdata_out, ydata_out = operation(key, xdata_in, ydata_in, input_x, input_y)
+                xdata_out, ydata_out = operation(xdata_in, input_x, input_y)
             except Exception as exception:
                 exception_type = exception.__class__.__name__
                 win = self.main_window
@@ -28,7 +28,7 @@ def on_accept(widget, self, window):
                 return
             self.datadict[key].xdata[start_index:stop_index] = xdata_out
             self.datadict[key].ydata[start_index:stop_index] = ydata_out
-        if self._mode != InteractionMode.SELECT:
+        if self.interaction_mode != InteractionMode.SELECT:
             xdata_in = self.datadict[key].xdata
             ydata_in = self.datadict[key].ydata
             try:
@@ -47,7 +47,7 @@ def on_accept(widget, self, window):
     window.destroy()
 
 
-def operation(key, xdata, ydata, input_x, input_y):
+def operation(xdata, input_x, input_y):
     x_array = []
     y_array = []
     operations = []
@@ -61,7 +61,7 @@ def operation(key, xdata, ydata, input_x, input_y):
         xy_operation = xy_operation.replace('^', '**')
         operations.append(xy_operation)
     x_operation, y_operation = operations[0], operations[1]
-    for index, value in enumerate(xdata):
+    for _index in enumerate(xdata):
         x_array.append(eval(x_operation))
         y_array.append(eval(y_operation))
     return x_array, y_array

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -21,8 +21,8 @@ def on_accept(widget, self, window):
             ydata_in = self.datadict[key].ydata[start_index:stop_index]
             try:
                 xdata_out, ydata_out = operation(key, xdata_in, ydata_in, input_x, input_y)
-            except Exception as e:
-                exception_type = e.__class__.__name__
+            except Exception as exception:
+                exception_type = exception.__class__.__name__
                 win = self.main_window
                 win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do transformation, make sure the syntax is correct'))
                 return
@@ -33,8 +33,8 @@ def on_accept(widget, self, window):
             ydata_in = self.datadict[key].ydata
             try:
                 xdata_out, ydata_out = operation(key, xdata_in, ydata_in, input_x, input_y)
-            except Exception as e:
-                exception_type = e.__class__.__name__
+            except Exception as excepton:
+                exception_type = exception.__class__.__name__
                 win = self.main_window
                 win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do transformation, make sure the syntax is correct'))
                 return

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -33,7 +33,7 @@ def on_accept(widget, self, window):
             ydata_in = self.datadict[key].ydata
             try:
                 xdata_out, ydata_out = operation(key, xdata_in, ydata_in, input_x, input_y)
-            except Exception as excepton:
+            except Exception as exception:
                 exception_type = exception.__class__.__name__
                 win = self.main_window
                 win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do transformation, make sure the syntax is correct'))

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -24,7 +24,9 @@ def on_accept(_widget, self, window):
             except Exception as exception:
                 exception_type = exception.__class__.__name__
                 win = self.main_window
-                win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do transformation, make sure the syntax is correct"))
+                toast = f"{exception_type}: Unable to do transformation, "
+                + "make sure the syntax is correct"
+                win.toast_overlay.add_toast(Adw.Toast(title=toast))
                 return
             self.datadict[key].xdata[start_index:stop_index] = xdata_out
             self.datadict[key].ydata[start_index:stop_index] = ydata_out
@@ -32,15 +34,20 @@ def on_accept(_widget, self, window):
             xdata_in = self.datadict[key].xdata
             ydata_in = self.datadict[key].ydata
             try:
-                xdata_out, ydata_out = operation(key, xdata_in, ydata_in, input_x, input_y)
+                xdata_out, ydata_out = operation(
+                    key, xdata_in, ydata_in, input_x, input_y)
             except Exception as exception:
                 exception_type = exception.__class__.__name__
                 win = self.main_window
-                win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do transformation, make sure the syntax is correct"))
+                toast = f"{exception_type}: Unable to do transformation, "
+                + "make sure the syntax is correct"
+                win.toast_overlay.add_toast(Adw.Toast(title=toast))
                 return
             self.datadict[key].xdata = xdata_out
             self.datadict[key].ydata = ydata_out
-        self.datadict[key].xdata, self.datadict[key].ydata = item_operations.sort_data(self.datadict[key].xdata, self.datadict[key].ydata)
+        self.datadict[key].xdata, self.datadict[
+            key].ydata = item_operations.sort_data(
+                self.datadict[key].xdata, self.datadict[key].ydata)
     item_operations.delete_selected_data(self)
     item_operations.add_to_clipboard(self)
     plotting_tools.refresh_plot(self)
@@ -81,6 +88,7 @@ class TransformWindow(Adw.Window):
 
         self.transform_x_entry.set_text("X")
         self.transform_y_entry.set_text("Y")
-        self.transform_confirm_button.connect("clicked", on_accept, parent, self)
+        self.transform_confirm_button.connect(
+            "clicked", on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -15,7 +15,7 @@ def on_accept(_widget, self, window):
         _selection, start_stop = item_operations.select_data(self)
 
     for key in selected_keys:
-        if f'{key}_selected' in self.datadict:
+        if f"{key}_selected" in self.datadict:
             start_index, stop_index = start_stop[key][0], start_stop[key][1]
             xdata_in = self.datadict[key].xdata[start_index:stop_index]
             ydata_in = self.datadict[key].ydata[start_index:stop_index]
@@ -24,7 +24,7 @@ def on_accept(_widget, self, window):
             except Exception as exception:
                 exception_type = exception.__class__.__name__
                 win = self.main_window
-                win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do transformation, make sure the syntax is correct'))
+                win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do transformation, make sure the syntax is correct"))
                 return
             self.datadict[key].xdata[start_index:stop_index] = xdata_out
             self.datadict[key].ydata[start_index:stop_index] = ydata_out
@@ -36,7 +36,7 @@ def on_accept(_widget, self, window):
             except Exception as exception:
                 exception_type = exception.__class__.__name__
                 win = self.main_window
-                win.toast_overlay.add_toast(Adw.Toast(title=f'{exception_type}: Unable to do transformation, make sure the syntax is correct'))
+                win.toast_overlay.add_toast(Adw.Toast(title=f"{exception_type}: Unable to do transformation, make sure the syntax is correct"))
                 return
             self.datadict[key].xdata = xdata_out
             self.datadict[key].ydata = ydata_out
@@ -52,13 +52,13 @@ def operation(xdata, input_x, input_y):
     y_array = []
     operations = []
     for xy_operation in [input_x, input_y]:
-        xy_operation = xy_operation.replace('Y_range', 'y_range')
-        xy_operation = xy_operation.replace('X_range', 'x_range')
-        xy_operation = xy_operation.replace('Y', 'ydata[index]')
-        xy_operation = xy_operation.replace('X', 'xdata[index]')
-        xy_operation = xy_operation.replace('y_range', 'Y_range')
-        xy_operation = xy_operation.replace('x_range', 'X_range')
-        xy_operation = xy_operation.replace('^', '**')
+        xy_operation = xy_operation.replace("Y_range", "y_range")
+        xy_operation = xy_operation.replace("X_range", "x_range")
+        xy_operation = xy_operation.replace("Y", "ydata[index]")
+        xy_operation = xy_operation.replace("X", "xdata[index]")
+        xy_operation = xy_operation.replace("y_range", "Y_range")
+        xy_operation = xy_operation.replace("x_range", "X_range")
+        xy_operation = xy_operation.replace("^", "**")
         operations.append(xy_operation)
     x_operation, y_operation = operations[0], operations[1]
     for _index in enumerate(xdata):
@@ -67,9 +67,9 @@ def operation(xdata, input_x, input_y):
     return x_array, y_array
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/transform_window.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/transform_window.ui")
 class TransformWindow(Adw.Window):
-    __gtype_name__ = 'TransformWindow'
+    __gtype_name__ = "TransformWindow"
     transform_x_entry = Gtk.Template.Child()
     transform_y_entry = Gtk.Template.Child()
     transform_confirm_button = Gtk.Template.Child()
@@ -77,10 +77,10 @@ class TransformWindow(Adw.Window):
     def __init__(self, parent):
         super().__init__()
         style_context = self.transform_confirm_button.get_style_context()
-        style_context.add_class('suggested-action')
+        style_context.add_class("suggested-action")
 
-        self.transform_x_entry.set_text('X')
-        self.transform_y_entry.set_text('Y')
-        self.transform_confirm_button.connect('clicked', on_accept, parent, self)
+        self.transform_x_entry.set_text("X")
+        self.transform_y_entry.set_text("Y")
+        self.transform_confirm_button.connect("clicked", on_accept, parent, self)
         self.set_transient_for(parent.main_window)
         self.set_modal(True)

--- a/src/ui.py
+++ b/src/ui.py
@@ -129,21 +129,21 @@ def export_figure(self):
         action=Gtk.FileChooserAction.SAVE,
         modal=True)
 
-    ff = Gtk.FileFilter()
-    ff.set_name('All files')
-    ff.add_pattern('*')
-    dialog.add_filter(ff)
-    dialog.set_filter(ff)
+    file_filter = Gtk.FileFilter()
+    file_filter.set_name('All files')
+    file_filter.add_pattern('*')
+    dialog.add_filter(file_filter)
+    dialog.set_filter(file_filter)
 
     formats = []
     default_format = None
     for i, (name, fmts) in enumerate(
             self.canvas.get_supported_filetypes_grouped().items()):
-        ff = Gtk.FileFilter()
-        ff.set_name(name)
+        file_filter = Gtk.FileFilter()
+        file_filter.set_name(name)
         for fmt in fmts:
-            ff.add_pattern(f'*.{fmt}')
-        dialog.add_filter(ff)
+            file_filter.add_pattern(f'*.{fmt}')
+        dialog.add_filter(file_filter)
         formats.append(name)
         if self.canvas.get_default_filetype() in fmts:
             default_format = i

--- a/src/ui.py
+++ b/src/ui.py
@@ -15,9 +15,11 @@ def toggle_sidebar(action, _shortcut, self):
 
 def toggle_darkmode(_shortcut, _theme, _widget, self):
     if Adw.StyleManager.get_default().get_dark():
-        self.plot_settings.plot_style = self.preferences.config["plot_style_dark"]
+        self.plot_settings.plot_style = self.preferences.config[
+            "plot_style_dark"]
     else:
-        self.plot_settings.plot_style = self.preferences.config["plot_style_light"]
+        self.plot_settings.plot_style = self.preferences.config[
+            "plot_style_light"]
     plotting_tools.reload_plot(self)
 
 
@@ -58,7 +60,8 @@ def open_file_dialog(self, open_project, import_settings=None):
     )
     open_file_chooser.set_modal(True)
     open_file_chooser.set_select_multiple(open_project)
-    open_file_chooser.connect("response", on_open_file_response, self, open_project, import_settings)
+    open_file_chooser.connect("response", on_open_file_response, self,
+                              open_project, import_settings)
     open_file_chooser.show()
 
 
@@ -109,7 +112,8 @@ def save_file_dialog(self):
         chooser.connect("response", on_save_response, self, False)
         chooser.show()
     except UnboundLocalError:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title="Could not open save dialog, make sure you have data opened"))
+        toast = "Could not open save dialog, make sure you have data opened"
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title=toast))
 
 
 def on_save_response(dialog, response, self, project):
@@ -121,7 +125,6 @@ def on_save_response(dialog, response, self, project):
             file_io.save_file(self, path)
 
 
-# https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L306
 def export_figure(self):
     dialog = Gtk.FileChooserNative(
         title="Save the figure",
@@ -159,7 +162,6 @@ def export_figure(self):
     dialog.show()
 
 
-# https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L344
 def on_figure_save_response(dialog, response, self):
     file = dialog.get_file()
     fmt = dialog.get_choice("format")
@@ -170,10 +172,15 @@ def on_figure_save_response(dialog, response, self):
     try:
         self.canvas.figure.savefig(file.get_path(), format=fmt)
     except Exception:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title="Unable to save image"))
+        self.main_window.toast_overlay.add_toast(
+            Adw.Toast(title="Unable to save image"))
 
 
 def show_about_window(self):
+    developers = [
+        "Sjoerd Broekhuijsen <contact@sjoerd.se>",
+        "Christoph Kohnen <christoph.kohnen@disroot.org>"
+    ]
     about = Adw.AboutWindow(transient_for=self.main_window,
                             application_name=self.name,
                             application_icon=self.appid,
@@ -181,12 +188,11 @@ def show_about_window(self):
                             developer_name=self.author,
                             issue_url=self.issues,
                             version=self.version,
-                            developers=[
-                                "Sjoerd Broekhuijsen <contact@sjoerd.se>",
-                                "Christoph Kohnen <christoph.kohnen@disroot.org>"
-                            ],
+                            developers=developers,
                             copyright=f"© {self.copyright} {self.author}",
                             license_type="GTK_LICENSE_GPL_3_0")
-    with open(os.path.join(os.getenv("XDG_DATA_DIRS")).split(":")[0] + "/graphs/graphs/whats_new", "r", encoding="utf-8") as file:
+    path = os.getenv("XDG_DATA_DIRS").split(":")[0]
+    with open(os.path.join(
+            path + "/graphs/graphs/whats_new"), "r", encoding="utf-8") as file:
         about.set_release_notes(file.read())
     about.present()

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,14 +1,17 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import os
-from gi.repository import GLib, Adw, Gtk
 
-from . import plotting_tools, file_io, graphs
+from gi.repository import Adw, GLib, Gtk
+
+from graphs import file_io, graphs, plotting_tools
+
 
 def toggle_sidebar(action, shortcut, self):
     flap = self.main_window.sidebar_flap
     enabled = not flap.get_reveal_flap()
     action.change_state(GLib.Variant.new_boolean(enabled))
     flap.set_reveal_flap(enabled)
+
 
 def toggle_darkmode(shortcut, theme, widget, self):
     if Adw.StyleManager.get_default().get_dark():
@@ -17,35 +20,36 @@ def toggle_darkmode(shortcut, theme, widget, self):
         self.plot_settings.plot_style = self.preferences.config['plot_style_light']
     plotting_tools.reload_plot(self)
 
+
 def enable_data_dependent_buttons(self, enabled):
     win = self.main_window
-
     dependent_buttons = [
-    win.shift_vertically_button,
-    win.translate_x_button,
-    win.translate_y_button,
-    win.multiply_x_button,
-    win.multiply_y_button,
-    win.smooth_button,
-    win.fourier_button,
-    win.inverse_fourier_button,
-    win.normalize_button,
-    win.center_data_button,
-    win.derivative_button,
-    win.integral_button,
-    win.transform_data_button,
-    win.combine_data_button,
+        win.shift_vertically_button,
+        win.translate_x_button,
+        win.translate_y_button,
+        win.multiply_x_button,
+        win.multiply_y_button,
+        win.smooth_button,
+        win.fourier_button,
+        win.inverse_fourier_button,
+        win.normalize_button,
+        win.center_data_button,
+        win.derivative_button,
+        win.integral_button,
+        win.transform_data_button,
+        win.combine_data_button,
     ]
-
     for button in dependent_buttons:
         button.set_sensitive(enabled)
+
 
 def disable_clipboard_buttons(self):
     win = self.main_window
     win.redo_button.set_sensitive(False)
     win.undo_button.set_sensitive(False)
 
-def open_file_dialog(self, open_project, import_settings = None):
+
+def open_file_dialog(self, open_project, import_settings=None):
     open_file_chooser = Gtk.FileChooserNative.new(
         title='Open new files',
         parent=self.main_window,
@@ -57,12 +61,14 @@ def open_file_dialog(self, open_project, import_settings = None):
     open_file_chooser.connect('response', on_open_file_response, self, open_project, import_settings)
     open_file_chooser.show()
 
+
 def on_open_file_response(dialog, response, self, project, import_settings):
     if response == Gtk.ResponseType.ACCEPT:
-        if(project):
+        if project:
             file_io.load_project(self, dialog.get_files())
         else:
             graphs.open_files(self, dialog.get_files(), import_settings)
+
 
 def save_project_dialog(self, documenttypes='Graphs Project (*)'):
     def save_project_chooser(action):
@@ -78,6 +84,7 @@ def save_project_dialog(self, documenttypes='Graphs Project (*)'):
     chooser.set_modal(True)
     chooser.connect('response', on_save_response, self, True)
     chooser.show()
+
 
 def save_file_dialog(self, documenttype='Text file (*.txt)'):
     def save_file_chooser(action):
@@ -102,7 +109,8 @@ def save_file_dialog(self, documenttype='Text file (*.txt)'):
         chooser.connect('response', on_save_response, self, False)
         chooser.show()
     except UnboundLocalError:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Could not open save dialog, make sure you have data opened'))
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title='Could not open save dialog, make sure you have data opened'))
+
 
 def on_save_response(dialog, response, self, project):
     if response == Gtk.ResponseType.ACCEPT:
@@ -111,6 +119,7 @@ def on_save_response(dialog, response, self, project):
             file_io.save_project(self, path)
         else:
             file_io.save_file(self, path)
+
 
 # https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L306
 def export_figure(self):
@@ -141,16 +150,17 @@ def export_figure(self):
     # Setting the choice doesn't always work, so make sure the default
     # format is first.
     formats = [formats[default_format], *formats[:default_format],
-               *formats[default_format+1:]]
+               *formats[default_format + 1:]]
     dialog.add_choice('format', 'File format', formats, formats)
     dialog.set_choice('format', formats[default_format])
 
     dialog.set_current_name(self.canvas.get_default_filename())
-    dialog.connect('response', on_save_response, self)
+    dialog.connect('response', on_figure_save_response, self)
     dialog.show()
 
+
 # https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L344
-def on_save_response(dialog, response, self):
+def on_figure_save_response(dialog, response, self):
     file = dialog.get_file()
     fmt = dialog.get_choice('format')
     fmt = self.canvas.get_supported_filetypes_grouped()[fmt][0]
@@ -159,12 +169,12 @@ def on_save_response(dialog, response, self):
         return
     try:
         self.canvas.figure.savefig(file.get_path(), format=fmt)
-    except Exception as e:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Unable to save image'))
+    except Exception:
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title='Unable to save image'))
+
 
 def show_about_window(self):
     whats_new = open(os.path.join(os.getenv('XDG_DATA_DIRS')).split(':')[0] + '/graphs/graphs/whats_new', 'r').read()
-    print(whats_new)
     about = Adw.AboutWindow(transient_for=self.main_window,
                             application_name=self.name,
                             application_icon=self.appid,
@@ -173,8 +183,8 @@ def show_about_window(self):
                             issue_url=self.issues,
                             version=self.version,
                             developers=[
-                            'Sjoerd Broekhuijsen <contact@sjoerd.se>',
-                            'Christoph Kohnen <christoph.kohnen@disroot.org>'
+                                'Sjoerd Broekhuijsen <contact@sjoerd.se>',
+                                'Christoph Kohnen <christoph.kohnen@disroot.org>'
                             ],
                             copyright=f'© {self.copyright} {self.author}',
                             license_type='GTK_LICENSE_GPL_3_0')

--- a/src/ui.py
+++ b/src/ui.py
@@ -12,9 +12,9 @@ def toggle_sidebar(action, shortcut, self):
 
 def toggle_darkmode(shortcut, theme, widget, self):
     if Adw.StyleManager.get_default().get_dark():
-        self.plot_settings.plot_style = self.preferences.config["plot_style_dark"]
+        self.plot_settings.plot_style = self.preferences.config['plot_style_dark']
     else:
-        self.plot_settings.plot_style = self.preferences.config["plot_style_light"]
+        self.plot_settings.plot_style = self.preferences.config['plot_style_light']
     plotting_tools.reload_plot(self)
 
 def enable_data_dependent_buttons(self, enabled):
@@ -47,14 +47,14 @@ def disable_clipboard_buttons(self):
 
 def open_file_dialog(self, open_project, import_settings = None):
     open_file_chooser = Gtk.FileChooserNative.new(
-        title="Open new files",
+        title='Open new files',
         parent=self.main_window,
         action=Gtk.FileChooserAction.OPEN,
-        accept_label="_Open",
+        accept_label='_Open',
     )
     open_file_chooser.set_modal(True)
     open_file_chooser.set_select_multiple(open_project)
-    open_file_chooser.connect("response", on_open_file_response, self, open_project, import_settings)
+    open_file_chooser.connect('response', on_open_file_response, self, open_project, import_settings)
     open_file_chooser.show()
 
 def on_open_file_response(dialog, response, self, project, import_settings):
@@ -64,28 +64,28 @@ def on_open_file_response(dialog, response, self, project, import_settings):
         else:
             graphs.open_files(self, dialog.get_files(), import_settings)
 
-def save_project_dialog(self, documenttypes="Graphs Project (*)"):
+def save_project_dialog(self, documenttypes='Graphs Project (*)'):
     def save_project_chooser(action):
         dialog = Gtk.FileChooserNative.new(
-            title="Save files",
+            title='Save files',
             parent=self.main_window,
             action=action,
-            accept_label="_Save",
+            accept_label='_Save',
         )
         return dialog
 
     chooser = save_project_chooser(Gtk.FileChooserAction.SAVE)
     chooser.set_modal(True)
-    chooser.connect("response", on_save_response, self, True)
+    chooser.connect('response', on_save_response, self, True)
     chooser.show()
 
-def save_file_dialog(self, documenttype="Text file (*.txt)"):
+def save_file_dialog(self, documenttype='Text file (*.txt)'):
     def save_file_chooser(action):
         dialog = Gtk.FileChooserNative.new(
-            title="Save files",
+            title='Save files',
             parent=self.main_window,
             action=action,
-            accept_label="_Save",
+            accept_label='_Save',
         )
         return dialog
 
@@ -96,13 +96,13 @@ def save_file_dialog(self, documenttype="Text file (*.txt)"):
 
     if len(self.datadict) == 1:
         filename = list(self.datadict.values())[0].filename
-        chooser.set_current_name(f"{filename}.txt")
+        chooser.set_current_name(f'{filename}.txt')
     try:
         chooser.set_modal(True)
-        chooser.connect("response", on_save_response, self, False)
+        chooser.connect('response', on_save_response, self, False)
         chooser.show()
     except UnboundLocalError:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"Could not open save dialog, make sure you have data opened"))
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Could not open save dialog, make sure you have data opened'))
 
 def on_save_response(dialog, response, self, project):
     if response == Gtk.ResponseType.ACCEPT:
@@ -146,7 +146,7 @@ def export_figure(self):
     dialog.set_choice('format', formats[default_format])
 
     dialog.set_current_name(self.canvas.get_default_filename())
-    dialog.connect("response", on_save_response, self)
+    dialog.connect('response', on_save_response, self)
     dialog.show()
 
 # https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L344
@@ -160,10 +160,10 @@ def on_save_response(dialog, response, self):
     try:
         self.canvas.figure.savefig(file.get_path(), format=fmt)
     except Exception as e:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f"Unable to save image"))
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title=f'Unable to save image'))
 
 def show_about_window(self):
-    whats_new = open(os.path.join(os.getenv('XDG_DATA_DIRS')).split(":")[0] + '/graphs/graphs/whats_new', 'r').read()
+    whats_new = open(os.path.join(os.getenv('XDG_DATA_DIRS')).split(':')[0] + '/graphs/graphs/whats_new', 'r').read()
     print(whats_new)
     about = Adw.AboutWindow(transient_for=self.main_window,
                             application_name=self.name,

--- a/src/ui.py
+++ b/src/ui.py
@@ -6,14 +6,14 @@ from gi.repository import Adw, GLib, Gtk
 from graphs import file_io, graphs, plotting_tools
 
 
-def toggle_sidebar(action, shortcut, self):
+def toggle_sidebar(action, _shortcut, self):
     flap = self.main_window.sidebar_flap
     enabled = not flap.get_reveal_flap()
     action.change_state(GLib.Variant.new_boolean(enabled))
     flap.set_reveal_flap(enabled)
 
 
-def toggle_darkmode(shortcut, theme, widget, self):
+def toggle_darkmode(shortcut, _theme, _widget, self):
     if Adw.StyleManager.get_default().get_dark():
         self.plot_settings.plot_style = self.preferences.config['plot_style_dark']
     else:
@@ -70,7 +70,7 @@ def on_open_file_response(dialog, response, self, project, import_settings):
             graphs.open_files(self, dialog.get_files(), import_settings)
 
 
-def save_project_dialog(self, documenttypes='Graphs Project (*)'):
+def save_project_dialog(self):
     def save_project_chooser(action):
         dialog = Gtk.FileChooserNative.new(
             title='Save files',
@@ -86,7 +86,7 @@ def save_project_dialog(self, documenttypes='Graphs Project (*)'):
     chooser.show()
 
 
-def save_file_dialog(self, documenttype='Text file (*.txt)'):
+def save_file_dialog(self):
     def save_file_chooser(action):
         dialog = Gtk.FileChooserNative.new(
             title='Save files',
@@ -174,7 +174,6 @@ def on_figure_save_response(dialog, response, self):
 
 
 def show_about_window(self):
-    whats_new = open(os.path.join(os.getenv('XDG_DATA_DIRS')).split(':')[0] + '/graphs/graphs/whats_new', 'r').read()
     about = Adw.AboutWindow(transient_for=self.main_window,
                             application_name=self.name,
                             application_icon=self.appid,
@@ -188,5 +187,6 @@ def show_about_window(self):
                             ],
                             copyright=f'© {self.copyright} {self.author}',
                             license_type='GTK_LICENSE_GPL_3_0')
-    about.set_release_notes(whats_new)
+    with open(os.path.join(os.getenv('XDG_DATA_DIRS')).split(':')[0] + '/graphs/graphs/whats_new', 'r', encoding='utf-8') as file:
+        about.set_release_notes(file.read())
     about.present()

--- a/src/ui.py
+++ b/src/ui.py
@@ -13,7 +13,7 @@ def toggle_sidebar(action, _shortcut, self):
     flap.set_reveal_flap(enabled)
 
 
-def toggle_darkmode(shortcut, _theme, _widget, self):
+def toggle_darkmode(_shortcut, _theme, _widget, self):
     if Adw.StyleManager.get_default().get_dark():
         self.plot_settings.plot_style = self.preferences.config['plot_style_dark']
     else:

--- a/src/ui.py
+++ b/src/ui.py
@@ -15,9 +15,9 @@ def toggle_sidebar(action, _shortcut, self):
 
 def toggle_darkmode(_shortcut, _theme, _widget, self):
     if Adw.StyleManager.get_default().get_dark():
-        self.plot_settings.plot_style = self.preferences.config['plot_style_dark']
+        self.plot_settings.plot_style = self.preferences.config["plot_style_dark"]
     else:
-        self.plot_settings.plot_style = self.preferences.config['plot_style_light']
+        self.plot_settings.plot_style = self.preferences.config["plot_style_light"]
     plotting_tools.reload_plot(self)
 
 
@@ -51,14 +51,14 @@ def disable_clipboard_buttons(self):
 
 def open_file_dialog(self, open_project, import_settings=None):
     open_file_chooser = Gtk.FileChooserNative.new(
-        title='Open new files',
+        title="Open new files",
         parent=self.main_window,
         action=Gtk.FileChooserAction.OPEN,
-        accept_label='_Open',
+        accept_label="_Open",
     )
     open_file_chooser.set_modal(True)
     open_file_chooser.set_select_multiple(open_project)
-    open_file_chooser.connect('response', on_open_file_response, self, open_project, import_settings)
+    open_file_chooser.connect("response", on_open_file_response, self, open_project, import_settings)
     open_file_chooser.show()
 
 
@@ -73,26 +73,26 @@ def on_open_file_response(dialog, response, self, project, import_settings):
 def save_project_dialog(self):
     def save_project_chooser(action):
         dialog = Gtk.FileChooserNative.new(
-            title='Save files',
+            title="Save files",
             parent=self.main_window,
             action=action,
-            accept_label='_Save',
+            accept_label="_Save",
         )
         return dialog
 
     chooser = save_project_chooser(Gtk.FileChooserAction.SAVE)
     chooser.set_modal(True)
-    chooser.connect('response', on_save_response, self, True)
+    chooser.connect("response", on_save_response, self, True)
     chooser.show()
 
 
 def save_file_dialog(self):
     def save_file_chooser(action):
         dialog = Gtk.FileChooserNative.new(
-            title='Save files',
+            title="Save files",
             parent=self.main_window,
             action=action,
-            accept_label='_Save',
+            accept_label="_Save",
         )
         return dialog
 
@@ -103,13 +103,13 @@ def save_file_dialog(self):
 
     if len(self.datadict) == 1:
         filename = list(self.datadict.values())[0].filename
-        chooser.set_current_name(f'{filename}.txt')
+        chooser.set_current_name(f"{filename}.txt")
     try:
         chooser.set_modal(True)
-        chooser.connect('response', on_save_response, self, False)
+        chooser.connect("response", on_save_response, self, False)
         chooser.show()
     except UnboundLocalError:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title='Could not open save dialog, make sure you have data opened'))
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title="Could not open save dialog, make sure you have data opened"))
 
 
 def on_save_response(dialog, response, self, project):
@@ -124,14 +124,14 @@ def on_save_response(dialog, response, self, project):
 # https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L306
 def export_figure(self):
     dialog = Gtk.FileChooserNative(
-        title='Save the figure',
+        title="Save the figure",
         transient_for=self.main_window,
         action=Gtk.FileChooserAction.SAVE,
         modal=True)
 
     file_filter = Gtk.FileFilter()
-    file_filter.set_name('All files')
-    file_filter.add_pattern('*')
+    file_filter.set_name("All files")
+    file_filter.add_pattern("*")
     dialog.add_filter(file_filter)
     dialog.set_filter(file_filter)
 
@@ -142,27 +142,27 @@ def export_figure(self):
         file_filter = Gtk.FileFilter()
         file_filter.set_name(name)
         for fmt in fmts:
-            file_filter.add_pattern(f'*.{fmt}')
+            file_filter.add_pattern(f"*.{fmt}")
         dialog.add_filter(file_filter)
         formats.append(name)
         if self.canvas.get_default_filetype() in fmts:
             default_format = i
-    # Setting the choice doesn't always work, so make sure the default
+    # Setting the choice doesn"t always work, so make sure the default
     # format is first.
     formats = [formats[default_format], *formats[:default_format],
                *formats[default_format + 1:]]
-    dialog.add_choice('format', 'File format', formats, formats)
-    dialog.set_choice('format', formats[default_format])
+    dialog.add_choice("format", "File format", formats, formats)
+    dialog.set_choice("format", formats[default_format])
 
     dialog.set_current_name(self.canvas.get_default_filename())
-    dialog.connect('response', on_figure_save_response, self)
+    dialog.connect("response", on_figure_save_response, self)
     dialog.show()
 
 
 # https://github.com/matplotlib/matplotlib/blob/c23ccdde6f0f8c071b09a88770e24452f2859e99/lib/matplotlib/backends/backend_gtk4.py#L344
 def on_figure_save_response(dialog, response, self):
     file = dialog.get_file()
-    fmt = dialog.get_choice('format')
+    fmt = dialog.get_choice("format")
     fmt = self.canvas.get_supported_filetypes_grouped()[fmt][0]
     dialog.destroy()
     if response != Gtk.ResponseType.ACCEPT:
@@ -170,7 +170,7 @@ def on_figure_save_response(dialog, response, self):
     try:
         self.canvas.figure.savefig(file.get_path(), format=fmt)
     except Exception:
-        self.main_window.toast_overlay.add_toast(Adw.Toast(title='Unable to save image'))
+        self.main_window.toast_overlay.add_toast(Adw.Toast(title="Unable to save image"))
 
 
 def show_about_window(self):
@@ -182,11 +182,11 @@ def show_about_window(self):
                             issue_url=self.issues,
                             version=self.version,
                             developers=[
-                                'Sjoerd Broekhuijsen <contact@sjoerd.se>',
-                                'Christoph Kohnen <christoph.kohnen@disroot.org>'
+                                "Sjoerd Broekhuijsen <contact@sjoerd.se>",
+                                "Christoph Kohnen <christoph.kohnen@disroot.org>"
                             ],
-                            copyright=f'© {self.copyright} {self.author}',
-                            license_type='GTK_LICENSE_GPL_3_0')
-    with open(os.path.join(os.getenv('XDG_DATA_DIRS')).split(':')[0] + '/graphs/graphs/whats_new', 'r', encoding='utf-8') as file:
+                            copyright=f"© {self.copyright} {self.author}",
+                            license_type="GTK_LICENSE_GPL_3_0")
+    with open(os.path.join(os.getenv("XDG_DATA_DIRS")).split(":")[0] + "/graphs/graphs/whats_new", "r", encoding="utf-8") as file:
         about.set_release_notes(file.read())
     about.present()

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Gdk
 
-from .data import Data
+from graphs.data import Data
+
 
 def remove_unused_config_keys(config, template):
     delete_list = []
@@ -11,7 +12,8 @@ def remove_unused_config_keys(config, template):
     for key in delete_list:
         del config[key]
     return config
-    
+
+
 def add_new_config_keys(config, template):
     add_list = []
     for key in template.keys():
@@ -19,7 +21,8 @@ def add_new_config_keys(config, template):
             add_list.append(key)
     for key in add_list:
         config[key] = template[key]
-    return config     
+    return config
+
 
 def set_chooser(chooser, choice):
     """
@@ -30,6 +33,7 @@ def set_chooser(chooser, choice):
         if option.get_string() == choice:
             chooser.set_selected(index)
 
+
 def empty_chooser(chooser):
     """
     Remove all the values in a dropdown menu
@@ -37,8 +41,9 @@ def empty_chooser(chooser):
     model = chooser.get_model()
     for item in model:
         model.remove(0)
-        
-def populate_chooser(chooser, chooser_list, clear = True):
+
+
+def populate_chooser(chooser, chooser_list, clear=True):
     """
     Fill the dropdown menu with the strings in a chooser_list
     """
@@ -49,12 +54,14 @@ def populate_chooser(chooser, chooser_list, clear = True):
     for item in chooser_list:
         if item != 'nothing':
             model.append(str(item))
-            
+
+
 def get_datalist(parent):
     """
     Get a list of all data id's present in the datadict dictionary
     """
     return list(parent.datadict.keys())
+
 
 def get_all_filenames(parent):
     """
@@ -65,6 +72,7 @@ def get_all_filenames(parent):
         filenames.append(item[1].filename)
     return filenames
 
+
 def get_dict_by_value(dictionary, value):
     """
     Swap the keys and items of a dictionary
@@ -73,7 +81,8 @@ def get_dict_by_value(dictionary, value):
     if value == 'none':
         return 'none'
     return new_dict[value]
-    
+
+
 def get_font_weight(font_name):
     """
     Get the weight of the font that is used using the full font name
@@ -87,6 +96,7 @@ def get_font_weight(font_name):
         new_weight = 'normal'
     return new_weight
 
+
 def get_font_style(font_name):
     """
     Get the style of the font that is used using the full font name
@@ -95,6 +105,7 @@ def get_font_style(font_name):
     if font_name[-2] == ('italic' or 'oblique' or 'normal'):
         new_style = font_name[-2]
     return new_style
+
 
 def get_selected_keys(self):
     """
@@ -105,8 +116,9 @@ def get_selected_keys(self):
         if item.check_button.get_active():
             selected_keys.append(item.key)
     return selected_keys
-    
-def create_data(self, xdata = [], ydata = [], name = 'New data'):
+
+
+def create_data(self, xdata=[], ydata=[], name='New data'):
     """
     Create a new dataset using the xdata, ydata and name of the dataset as argument
     """
@@ -121,7 +133,8 @@ def create_data(self, xdata = [], ydata = [], name = 'New data'):
     new_file.selected_marker_size = self.preferences.config['plot_selected_marker_size']
     new_file.unselected_marker_size = self.preferences.config['plot_unselected_marker_size']
     return new_file
-    
+
+
 def create_rgba(r, g, b, a=1):
     """
     Create a valid RGBA object from rgba values.
@@ -133,14 +146,18 @@ def create_rgba(r, g, b, a=1):
     res.alpha = a
     return res
 
+
 def lookup_color(self, color):
     return self.main_window.get_style_context().lookup_color(color)[1]
 
+
 def rgba_to_hex(rgba):
-    return '#{:02x}{:02x}{:02x}'.format(round(rgba.red*255), round(rgba.green*255), round(rgba.blue*255), round(rgba.alpha*255))
+    return '#{:02x}{:02x}{:02x}'.format(round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255))
+
 
 def rgba_to_tuple(rgba):
     return (rgba.red, rgba.green, rgba.blue, rgba.alpha)
+
 
 def get_duplicate_filename(self, name):
     loop = True
@@ -154,9 +171,9 @@ def get_duplicate_filename(self, name):
                 loop = True
     return new_name
 
+
 def swap(str1):
     str1 = str1.replace(',', 'third')
     str1 = str1.replace('.', ', ')
     str1 = str1.replace('third', '.')
     return str1
-

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -135,15 +135,15 @@ def create_data(self, xdata=[], ydata=[], name='New data'):
     return new_file
 
 
-def create_rgba(r, g, b, a=1):
+def create_rgba(red, green, blue, alpha=1):
     """
     Create a valid RGBA object from rgba values.
     """
     res = Gdk.RGBA()
-    res.red = r
-    res.green = g
-    res.blue = b
-    res.alpha = a
+    res.red = red
+    res.green = green
+    res.blue = blue
+    res.alpha = alpha
     return res
 
 

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -47,7 +47,7 @@ def populate_chooser(chooser, chooser_list, clear = True):
         for item in model:
             model.remove(0)
     for item in chooser_list:
-        if item != "nothing":
+        if item != 'nothing':
             model.append(str(item))
             
 def get_datalist(parent):
@@ -70,8 +70,8 @@ def get_dict_by_value(dictionary, value):
     Swap the keys and items of a dictionary
     """
     new_dict = dict((v, k) for k, v in dictionary.items())
-    if value == "none":
-        return "none"
+    if value == 'none':
+        return 'none'
     return new_dict[value]
     
 def get_font_weight(font_name):
@@ -79,20 +79,20 @@ def get_font_weight(font_name):
     Get the weight of the font that is used using the full font name
     """
     valid_weights = ['normal', 'bold', 'heavy', 'light', 'ultrabold', 'ultralight']
-    if font_name[-2] != "italic":
+    if font_name[-2] != 'italic':
         new_weight = font_name[-2]
     else:
         new_weight = font_name[-3]
     if new_weight not in valid_weights:
-        new_weight = "normal"
+        new_weight = 'normal'
     return new_weight
 
 def get_font_style(font_name):
     """
     Get the style of the font that is used using the full font name
     """
-    new_style = "normal"
-    if font_name[-2] == ("italic" or "oblique" or "normal"):
+    new_style = 'normal'
+    if font_name[-2] == ('italic' or 'oblique' or 'normal'):
         new_style = font_name[-2]
     return new_style
 
@@ -106,20 +106,20 @@ def get_selected_keys(self):
             selected_keys.append(item.key)
     return selected_keys
     
-def create_data(self, xdata = [], ydata = [], name = "New data"):
+def create_data(self, xdata = [], ydata = [], name = 'New data'):
     """
     Create a new dataset using the xdata, ydata and name of the dataset as argument
     """
     new_file = Data(xdata, ydata)
     new_file.filename = name
-    new_file.linestyle_selected = self.preferences.config["plot_selected_linestyle"]
-    new_file.linestyle_unselected = self.preferences.config["plot_unselected_linestyle"]
-    new_file.selected_line_thickness = self.preferences.config["selected_linewidth"]
-    new_file.unselected_line_thickness = self.preferences.config["unselected_linewidth"]
-    new_file.selected_markers = self.preferences.config["plot_selected_markers"]
-    new_file.unselected_markers = self.preferences.config["plot_unselected_markers"]
-    new_file.selected_marker_size = self.preferences.config["plot_selected_marker_size"]
-    new_file.unselected_marker_size = self.preferences.config["plot_unselected_marker_size"]
+    new_file.linestyle_selected = self.preferences.config['plot_selected_linestyle']
+    new_file.linestyle_unselected = self.preferences.config['plot_unselected_linestyle']
+    new_file.selected_line_thickness = self.preferences.config['selected_linewidth']
+    new_file.unselected_line_thickness = self.preferences.config['unselected_linewidth']
+    new_file.selected_markers = self.preferences.config['plot_selected_markers']
+    new_file.unselected_markers = self.preferences.config['plot_unselected_markers']
+    new_file.selected_marker_size = self.preferences.config['plot_selected_marker_size']
+    new_file.unselected_marker_size = self.preferences.config['plot_unselected_marker_size']
     return new_file
     
 def create_rgba(r, g, b, a=1):
@@ -147,7 +147,7 @@ def get_duplicate_filename(self, name):
     i = 0
     while loop:
         i += 1
-        new_name = f"{name} ({i})"
+        new_name = f'{name} ({i})'
         loop = False
         for key, item in self.datadict.items():
             if new_name == item.filename:

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -39,7 +39,7 @@ def empty_chooser(chooser):
     Remove all the values in a dropdown menu
     """
     model = chooser.get_model()
-    for item in model:
+    for _index in model:
         model.remove(0)
 
 
@@ -112,7 +112,7 @@ def get_selected_keys(self):
     Get a list of the ID's of all the datasets that are currently selected
     """
     selected_keys = []
-    for key, item in self.item_rows.items():
+    for _key, item in self.item_rows.items():
         if item.check_button.get_active():
             selected_keys.append(item.key)
     return selected_keys
@@ -166,7 +166,7 @@ def get_duplicate_filename(self, name):
         i += 1
         new_name = f'{name} ({i})'
         loop = False
-        for key, item in self.datadict.items():
+        for _key, item in self.datadict.items():
             if new_name == item.filename:
                 loop = True
     return new_name

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -46,12 +46,12 @@ def populate_chooser(chooser, chooser_list, clear=True):
         for item in model:
             model.remove(0)
     for item in chooser_list:
-        if item != 'nothing':
+        if item != "nothing":
             model.append(str(item))
 
 
 def get_datalist(parent):
-    """Get a list of all data id's present in the datadict dictionary"""
+    """Get a list of all data id"s present in the datadict dictionary"""
     return list(parent.datadict.keys())
 
 
@@ -66,27 +66,27 @@ def get_all_filenames(parent):
 def get_dict_by_value(dictionary, value):
     """Swap the keys and items of a dictionary"""
     new_dict = {(k, v): (v, k) for k, v in dictionary.items()}
-    if value == 'none':
-        return 'none'
+    if value == "none":
+        return "none"
     return new_dict[value]
 
 
 def get_font_weight(font_name):
     """Get the weight of the font that is used using the full font name"""
-    valid_weights = ['normal', 'bold', 'heavy', 'light', 'ultrabold', 'ultralight']
-    if font_name[-2] != 'italic':
+    valid_weights = ["normal", "bold", "heavy", "light", "ultrabold", "ultralight"]
+    if font_name[-2] != "italic":
         new_weight = font_name[-2]
     else:
         new_weight = font_name[-3]
     if new_weight not in valid_weights:
-        new_weight = 'normal'
+        new_weight = "normal"
     return new_weight
 
 
 def get_font_style(font_name):
     """Get the style of the font that is used using the full font name"""
-    new_style = 'normal'
-    if font_name[-2] == ('italic' or 'oblique' or 'normal'):
+    new_style = "normal"
+    if font_name[-2] == ("italic" or "oblique" or "normal"):
         new_style = font_name[-2]
     return new_style
 
@@ -100,18 +100,18 @@ def get_selected_keys(self):
     return selected_keys
 
 
-def create_data(self, xdata=[], ydata=[], name='New data'):
+def create_data(self, xdata=[], ydata=[], name="New data"):
     """Create a new dataset using the xdata, ydata and name of the dataset as argument"""
     new_file = Data(xdata, ydata)
     new_file.filename = name
-    new_file.linestyle_selected = self.preferences.config['plot_selected_linestyle']
-    new_file.linestyle_unselected = self.preferences.config['plot_unselected_linestyle']
-    new_file.selected_line_thickness = self.preferences.config['selected_linewidth']
-    new_file.unselected_line_thickness = self.preferences.config['unselected_linewidth']
-    new_file.selected_markers = self.preferences.config['plot_selected_markers']
-    new_file.unselected_markers = self.preferences.config['plot_unselected_markers']
-    new_file.selected_marker_size = self.preferences.config['plot_selected_marker_size']
-    new_file.unselected_marker_size = self.preferences.config['plot_unselected_marker_size']
+    new_file.linestyle_selected = self.preferences.config["plot_selected_linestyle"]
+    new_file.linestyle_unselected = self.preferences.config["plot_unselected_linestyle"]
+    new_file.selected_line_thickness = self.preferences.config["selected_linewidth"]
+    new_file.unselected_line_thickness = self.preferences.config["unselected_linewidth"]
+    new_file.selected_markers = self.preferences.config["plot_selected_markers"]
+    new_file.unselected_markers = self.preferences.config["plot_unselected_markers"]
+    new_file.selected_marker_size = self.preferences.config["plot_selected_marker_size"]
+    new_file.unselected_marker_size = self.preferences.config["plot_unselected_marker_size"]
     return new_file
 
 
@@ -130,7 +130,7 @@ def lookup_color(self, color):
 
 
 def rgba_to_hex(rgba):
-    return '#{:02x}{:02x}{:02x}'.format(round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255))
+    return "#{:02x}{:02x}{:02x}".format(round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255))
 
 
 def rgba_to_tuple(rgba):
@@ -142,7 +142,7 @@ def get_duplicate_filename(self, name):
     i = 0
     while loop:
         i += 1
-        new_name = f'{name} ({i})'
+        new_name = f"{name} ({i})"
         loop = False
         for _key, item in self.datadict.items():
             if new_name == item.filename:
@@ -151,7 +151,7 @@ def get_duplicate_filename(self, name):
 
 
 def swap(str1):
-    str1 = str1.replace(',', 'third')
-    str1 = str1.replace('.', ', ')
-    str1 = str1.replace('third', '.')
+    str1 = str1.replace(",", "third")
+    str1 = str1.replace(".", ", ")
+    str1 = str1.replace("third", ".")
     return str1

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -25,9 +25,7 @@ def add_new_config_keys(config, template):
 
 
 def set_chooser(chooser, choice):
-    """
-    Set the value of a dropdown menu to the choice parameter string
-    """
+    """Set the value of a dropdown menu to the choice parameter string"""
     model = chooser.get_model()
     for index, option in enumerate(model):
         if option.get_string() == choice:
@@ -35,18 +33,14 @@ def set_chooser(chooser, choice):
 
 
 def empty_chooser(chooser):
-    """
-    Remove all the values in a dropdown menu
-    """
+    """Remove all the values in a dropdown menu"""
     model = chooser.get_model()
     for _index in model:
         model.remove(0)
 
 
 def populate_chooser(chooser, chooser_list, clear=True):
-    """
-    Fill the dropdown menu with the strings in a chooser_list
-    """
+    """Fill the dropdown menu with the strings in a chooser_list"""
     model = chooser.get_model()
     if clear:
         for item in model:
@@ -57,16 +51,12 @@ def populate_chooser(chooser, chooser_list, clear=True):
 
 
 def get_datalist(parent):
-    """
-    Get a list of all data id's present in the datadict dictionary
-    """
+    """Get a list of all data id's present in the datadict dictionary"""
     return list(parent.datadict.keys())
 
 
 def get_all_filenames(parent):
-    """
-    Get a list of all filenames present in the datadict dictionary
-    """
+    """Get a list of all filenames present in the datadict dictionary"""
     filenames = []
     for item in parent.datadict.items():
         filenames.append(item[1].filename)
@@ -74,19 +64,15 @@ def get_all_filenames(parent):
 
 
 def get_dict_by_value(dictionary, value):
-    """
-    Swap the keys and items of a dictionary
-    """
-    new_dict = dict((v, k) for k, v in dictionary.items())
+    """Swap the keys and items of a dictionary"""
+    new_dict = {(k, v): (v, k) for k, v in dictionary.items()}
     if value == 'none':
         return 'none'
     return new_dict[value]
 
 
 def get_font_weight(font_name):
-    """
-    Get the weight of the font that is used using the full font name
-    """
+    """Get the weight of the font that is used using the full font name"""
     valid_weights = ['normal', 'bold', 'heavy', 'light', 'ultrabold', 'ultralight']
     if font_name[-2] != 'italic':
         new_weight = font_name[-2]
@@ -98,9 +84,7 @@ def get_font_weight(font_name):
 
 
 def get_font_style(font_name):
-    """
-    Get the style of the font that is used using the full font name
-    """
+    """Get the style of the font that is used using the full font name"""
     new_style = 'normal'
     if font_name[-2] == ('italic' or 'oblique' or 'normal'):
         new_style = font_name[-2]
@@ -108,9 +92,7 @@ def get_font_style(font_name):
 
 
 def get_selected_keys(self):
-    """
-    Get a list of the ID's of all the datasets that are currently selected
-    """
+    """Get a list of the ID's of all the datasets that are currently selected"""
     selected_keys = []
     for _key, item in self.item_rows.items():
         if item.check_button.get_active():
@@ -119,9 +101,7 @@ def get_selected_keys(self):
 
 
 def create_data(self, xdata=[], ydata=[], name='New data'):
-    """
-    Create a new dataset using the xdata, ydata and name of the dataset as argument
-    """
+    """Create a new dataset using the xdata, ydata and name of the dataset as argument"""
     new_file = Data(xdata, ydata)
     new_file.filename = name
     new_file.linestyle_selected = self.preferences.config['plot_selected_linestyle']
@@ -136,9 +116,7 @@ def create_data(self, xdata=[], ydata=[], name='New data'):
 
 
 def create_rgba(red, green, blue, alpha=1):
-    """
-    Create a valid RGBA object from rgba values.
-    """
+    """Create a valid RGBA object from rgba values."""
     res = Gdk.RGBA()
     res.red = red
     res.green = green

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -73,7 +73,8 @@ def get_dict_by_value(dictionary, value):
 
 def get_font_weight(font_name):
     """Get the weight of the font that is used using the full font name"""
-    valid_weights = ["normal", "bold", "heavy", "light", "ultrabold", "ultralight"]
+    valid_weights = ["normal", "bold", "heavy",
+                     "light", "ultrabold", "ultralight"]
     if font_name[-2] != "italic":
         new_weight = font_name[-2]
     else:
@@ -92,7 +93,7 @@ def get_font_style(font_name):
 
 
 def get_selected_keys(self):
-    """Get a list of the ID's of all the datasets that are currently selected"""
+    """Get a list of ID's of all the datasets that are currently selected"""
     selected_keys = []
     for _key, item in self.item_rows.items():
         if item.check_button.get_active():
@@ -101,17 +102,28 @@ def get_selected_keys(self):
 
 
 def create_data(self, xdata=[], ydata=[], name="New data"):
-    """Create a new dataset using the xdata, ydata and name of the dataset as argument"""
+    """
+    Create a new dataset using the xdata, ydata
+    and name of the dataset as argument
+    """
     new_file = Data(xdata, ydata)
     new_file.filename = name
-    new_file.linestyle_selected = self.preferences.config["plot_selected_linestyle"]
-    new_file.linestyle_unselected = self.preferences.config["plot_unselected_linestyle"]
-    new_file.selected_line_thickness = self.preferences.config["selected_linewidth"]
-    new_file.unselected_line_thickness = self.preferences.config["unselected_linewidth"]
-    new_file.selected_markers = self.preferences.config["plot_selected_markers"]
-    new_file.unselected_markers = self.preferences.config["plot_unselected_markers"]
-    new_file.selected_marker_size = self.preferences.config["plot_selected_marker_size"]
-    new_file.unselected_marker_size = self.preferences.config["plot_unselected_marker_size"]
+    new_file.linestyle_selected = self.preferences.config[
+        "plot_selected_linestyle"]
+    new_file.linestyle_unselected = self.preferences.config[
+        "plot_unselected_linestyle"]
+    new_file.selected_line_thickness = self.preferences.config[
+        "selected_linewidth"]
+    new_file.unselected_line_thickness = self.preferences.config[
+        "unselected_linewidth"]
+    new_file.selected_markers = self.preferences.config[
+        "plot_selected_markers"]
+    new_file.unselected_markers = self.preferences.config[
+        "plot_unselected_markers"]
+    new_file.selected_marker_size = self.preferences.config[
+        "plot_selected_marker_size"]
+    new_file.unselected_marker_size = self.preferences.config[
+        "plot_unselected_marker_size"]
     return new_file
 
 
@@ -130,7 +142,10 @@ def lookup_color(self, color):
 
 
 def rgba_to_hex(rgba):
-    return "#{:02x}{:02x}{:02x}".format(round(rgba.red * 255), round(rgba.green * 255), round(rgba.blue * 255))
+    return "#{:02x}{:02x}{:02x}".format(
+        round(rgba.red * 255),
+        round(rgba.green * 255),
+        round(rgba.blue * 255))
 
 
 def rgba_to_tuple(rgba):

--- a/src/window.py
+++ b/src/window.py
@@ -2,9 +2,9 @@
 from gi.repository import Adw, Gtk
 
 
-@Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/window.ui')
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/window.ui")
 class GraphsWindow(Adw.ApplicationWindow):
-    __gtype_name__ = 'GraphsWindow'
+    __gtype_name__ = "GraphsWindow"
     pan_button = Gtk.Template.Child()
     zoom_button = Gtk.Template.Child()
     select_button = Gtk.Template.Child()

--- a/src/window.py
+++ b/src/window.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
+
 @Gtk.Template(resource_path='/se/sjoerd/Graphs/ui/window.ui')
 class GraphsWindow(Adw.ApplicationWindow):
     __gtype_name__ = 'GraphsWindow'

--- a/src/window.py
+++ b/src/window.py
@@ -33,6 +33,3 @@ class GraphsWindow(Adw.ApplicationWindow):
     transform_data_button = Gtk.Template.Child()
     combine_data_button = Gtk.Template.Child()
     no_data_label_box = Gtk.Template.Child()
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [flake8]
 count = True
 #default_ignorelist: E121,E123,E126,E226,E24,E704,W503,W504
-ignore = E501, Q000
+ignore = E501, Q000, D
 inline-quotes = double

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,17 @@
 [flake8]
 count = True
 #default_ignorelist: E121,E123,E126,E226,E24,E704,W503,W504
-ignore = E501, Q000, D
+ignore =
+	# temporarily disable double quotes
+	Q000
+	# temporarily disable line too long
+	E501
+	# temporarily disable docstring related stuff
+	D100, D101, D102, D103, D107, D204, D205, D400, D401
 inline-quotes = double
+
+per-file-ignores =
+	main.py: F401
+	# As long as numpy should be available in its current state
+	add_equation.py: F403, F401
+	transform_data.py: F403, F401

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[flake8]
+count = True
+#default_ignorelist: E121,E123,E126,E226,E24,E704,W503,W504
+ignore = E501, Q000
+inline-quotes = double

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 count = True
 #default_ignorelist: E121,E123,E126,E226,E24,E704,W503,W504
 ignore = U101
-	# temporarily disable double quotes
-	Q000
 	# temporarily disable line too long
 	E501
 	# temporarily disable docstring related stuff

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [flake8]
 count = True
 #default_ignorelist: E121,E123,E126,E226,E24,E704,W503,W504
-ignore =
+ignore = U101
 	# temporarily disable double quotes
 	Q000
 	# temporarily disable line too long

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 count = True
 #default_ignorelist: E121,E123,E126,E226,E24,E704,W503,W504
 ignore = U101
-	# temporarily disable line too long
-	E501
 	# temporarily disable docstring related stuff
 	D100, D101, D102, D103, D107, D204, D205, D400, D401
 inline-quotes = double


### PR DESCRIPTION
Implements changes based on flake8 linting.
Sets up flake8 config to use for future CI runs and keep consistency across machines.

Currently, docstring related warnings are ignored, these might be more fit for a documentation-related pr.
The main problems with pylint atm are, that it is quite slow and needs to be properly set up in an environment, where all dependencies and the graphs module are properly installed. This makes up ca. 90% of the errors pylint raises, so I would mainly focus on flake8 linting for the moment.

As of now, only the following output remains (ignoring everything related to docstrings):

![image](https://user-images.githubusercontent.com/59118042/219459491-793ebf96-513f-489d-a409-96eb0e15016d.png)

A few notes on these:

- the numpy wildcart imports should be changed, but this is something, which has already been discussed, and I didn't want to change user-facing functionality on these ones
- the actions import on graphs is actually needed, but not recognized, I'll add these as an exception to the config
- The error in preferences I haven't gotten around to debug
- The error in utilities I haven't dared to change without fully understanding the function
