### PR TITLE
Define color button in blueprint

### DIFF
--- a/data/ui/sample_box.blp
+++ b/data/ui/sample_box.blp
@@ -21,6 +21,15 @@ template SampleBox : Box {
       hexpand: true;
     }
 
+    Button color_button {
+      tooltip-text: _("Pick a color");
+      styles ["flat"]
+      Image {
+        hexpand: false;
+        icon-name: "color-picker-symbolic";
+      }
+    }
+
     Button delete_button {
       tooltip-text: _("Remove");
       styles ["flat"]

--- a/data/ui/sample_box.blp
+++ b/data/ui/sample_box.blp
@@ -27,6 +27,7 @@ template SampleBox : Box {
       Image {
         hexpand: false;
         icon-name: "color-picker-symbolic";
+        pixel-size: 20;
       }
     }
 

--- a/src/colorpicker.py
+++ b/src/colorpicker.py
@@ -6,17 +6,13 @@ from graphs import plotting_tools, utilities
 from matplotlib import colors
 
 
-class ColorPicker(Gtk.Button):
-    def __init__(self, color, key, parent):
+class ColorPicker():
+    def __init__(self, color, key, parent, button):
         super().__init__()
         self.parent = parent
         self.key = key
-        self.set_tooltip_text("Pick a color")
+        self.button = button
         self.color = color
-        self.add_css_class("flat")
-        self.set_hexpand(False)
-        self.set_child(Gtk.Image.new_from_icon_name("color-picker-symbolic"))
-        self.get_child().set_pixel_size(20)
 
         press_gesture = Gtk.GestureClick()
         press_gesture.connect("pressed", self.change_color)
@@ -27,10 +23,10 @@ class ColorPicker(Gtk.Button):
         self.color_chooser.add_controller(press_gesture)
 
         self.color_popover = Gtk.Popover()
-        self.color_popover.set_parent(self)
+        self.color_popover.set_parent(self.button)
         self.color_popover.set_child(self.color_chooser)
         self.color_popover.connect("closed", self.change_color)
-        self.connect("clicked", self.on_click)
+        self.button.connect("clicked", self.on_click)
         self.set_css()
         self.color = self.get_color()
         parent.datadict[self.key].color = self.color
@@ -67,7 +63,7 @@ class ColorPicker(Gtk.Button):
 
     def set_css(self):
         self.provider = Gtk.CssProvider()
-        context = self.get_style_context()
+        context = self.button.get_style_context()
         context.add_provider(
             self.provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         rgba = utilities.create_rgba(*colors.to_rgba(self.color))

--- a/src/samplerow.py
+++ b/src/samplerow.py
@@ -13,6 +13,7 @@ class SampleBox(Gtk.Box):
     sample_box = Gtk.Template.Child()
     sample_id_label = Gtk.Template.Child()
     check_button = Gtk.Template.Child()
+    color_button = Gtk.Template.Child()
     delete_button = Gtk.Template.Child()
 
     def __init__(self, parent, key, color, label, selected=False):
@@ -32,9 +33,8 @@ class SampleBox(Gtk.Box):
         self.add_controller(self.gesture)
         self.gesture.connect("released", self.clicked, parent)
         self.delete_button.connect("clicked", self.delete)
-        self.color_picker = colorpicker.ColorPicker(color, key, parent)
-        self.sample_box.insert_child_after(
-            self.color_picker, self.sample_id_label)
+        self.color_picker = colorpicker.ColorPicker(color, key, parent,
+                                                    self.color_button)
         self.check_button.connect("toggled", self.toggled)
 
     def delete(self, _):


### PR DESCRIPTION
Colorpicker is no longer dependant on Gtk.Button, instead taking the already compiled(?) button from samplerow.
This should help ease the transition for Gnome 44