### PR TITLE
Fix style when loading project

### DIFF
--- a/src/file_io.py
+++ b/src/file_io.py
@@ -4,6 +4,8 @@ import os
 import pickle
 import re
 
+from gi.repository import Adw
+
 from graphs import graphs, plotting_tools, ui, utilities
 from graphs.data import Data
 
@@ -31,6 +33,11 @@ def load_project(self, files):
             project = pickle.load(file)
         project_datadict = project["data"]
         new_plot_settings = project["plot_settings"]
+        if Adw.StyleManager.get_default().get_dark():
+            style = self.preferences.config["plot_style_dark"]
+        else:
+            style = self.preferences.config["plot_style_light"]
+        new_plot_settings.plot_style = style
         self.plot_settings = new_plot_settings
         graphs.set_attributes(new_plot_settings, self.plot_settings)
         graphs.create_data_from_project(self, project_datadict)


### PR DESCRIPTION
When loading a project, that has been saved in Dark/Light mode in the respective other, the style remains. This sets the style based on config