### PR TITLE
Bugfixes + Fill in name automatically in plot settings

### DIFF
--- a/data/ui/plot_settings.blp
+++ b/data/ui/plot_settings.blp
@@ -28,8 +28,7 @@ template PlotSettingsWindow : Adw.PreferencesWindow {
       }
 
       Adw.EntryRow name_entry {
-        title: _("Change Name");
-        max-width-chars: 25;
+        title: _("Item name");
       }
 
       Adw.ComboRow plot_y_position {

--- a/src/calculation.py
+++ b/src/calculation.py
@@ -26,7 +26,7 @@ def operation(xdata, ydata, input_x, input_y):
     x_array = []
     y_array = []
     X_range = xdata
-    Y_Range = ydata
+    Y_range = ydata
     operations = []
     for xy_operation in [input_x, input_y]:
         xy_operation = xy_operation.replace("Y_range", "y_range")

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -52,7 +52,7 @@ def undo(self):
             item.clipboard_pos -= 1
     if abs(item.clipboard_pos) >= len(item.xdata_clipboard):
         undo_button.set_sensitive(False)
-    graphs.refresh(self)
+    graphs.refresh(self, set_limits=True)
 
 
 def redo(self):
@@ -70,4 +70,4 @@ def redo(self):
             item.ydata = item.ydata_clipboard[item.clipboard_pos].copy()
     if item.clipboard_pos >= -1:
         redo_button.set_sensitive(False)
-    graphs.refresh(self)
+    graphs.refresh(self, set_limits=True)

--- a/src/operations.py
+++ b/src/operations.py
@@ -80,7 +80,7 @@ def operation(self, callback, *args):
                     item.xdata = sorted_x
                     item.ydata = sorted_y
 
-        graphs.refresh(self)
+        graphs.refresh(self, set_limits=True)
     except Exception as exception:
         exception_type = exception.__class__.__name__
         message = f"Couldn't perform operation: {exception_type}"
@@ -154,7 +154,7 @@ def center(_item, xdata, ydata, center_maximum):
     elif center_maximum == "Center at middle coordinate":
         middle_value = (min(xdata) + max(xdata)) / 2
     new_xdata = [coordinate - middle_value for coordinate in xdata]
-    return new_xdata, ydata, False, False
+    return new_xdata, ydata, True, False
 
 
 def shift_vertically(item, xdata, ydata, yscale, right_scale):

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -191,8 +191,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
             self.plot_top_scale.get_selected_item().get_string()
         plot_settings.plot_style = \
             self.plot_style.get_selected_item().get_string()
-        if self.name_entry.get_text() != "":
-            item.filename = self.name_entry.get_text()
+        item.filename = self.name_entry.get_text()
         item.plot_Y_position = \
             self.plot_y_position.get_selected_item().get_string()
         item.plot_X_position = \

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -58,7 +58,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.present()
 
     def on_notify(self, _, __, parent):
-        self.save_settings(parent)
+        self.on_close(_, parent)
         filenames = utilities.get_all_filenames(parent)
         self.name_entry.set_text("")
         index = self.datalist_chooser.get_selected()
@@ -89,6 +89,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.plot_minor_tick_width.set_range(0, 4)
         self.plot_major_tick_length.set_range(0, 20)
         self.plot_minor_tick_length.set_range(0, 20)
+        self.name_entry.set_text(item.filename)
         self.plot_title.set_text(parent.plot_settings.title)
         self.plot_y_label.set_text(parent.plot_settings.ylabel)
         self.plot_x_label.set_text(parent.plot_settings.xlabel)

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -172,7 +172,7 @@ def change_left_yscale(action, target, self):
         self.canvas.ax.set_yscale("linear")
         self.plot_settings.yscale = "linear"
     action.change_state(target)
-    graphs.graphs.refresh(self)
+    graphs.refresh(self)
 
 
 def change_right_yscale(action, target, self):
@@ -185,7 +185,7 @@ def change_right_yscale(action, target, self):
         self.canvas.right_axis.set_yscale("linear")
         self.plot_settings.right_scale = "linear"
     action.change_state(target)
-    graphs.graphs.refresh(self)
+    graphs.refresh(self)
 
 
 def change_top_xscale(action, target, self):
@@ -198,7 +198,7 @@ def change_top_xscale(action, target, self):
         self.canvas.top_right_axis.set_xscale("linear")
         self.plot_settings.top_scale = "linear"
     action.change_state(target)
-    graphs.graphs.refresh(self)
+    graphs.refresh(self)
 
 
 def change_bottom_xscale(action, target, self):
@@ -211,7 +211,7 @@ def change_bottom_xscale(action, target, self):
         self.canvas.right_axis.set_xscale("linear")
         self.plot_settings.xscale = "linear"
     action.change_state(target)
-    graphs.graphs.refresh(self)
+    graphs.refresh(self)
 
 
 def get_next_color(self):


### PR DESCRIPTION
Fixes some bugs, plus automatically fills in the current name of an item in the plot settings. I've found while working with Graphs that you often just want to change a small thing in the name (fix a typo for instance, or add some information). It's annoying if you have to retype the entire name. It's also more consistent with general behaviour to have the name filled in that field already, and let it react if the user changes is. (Such as already is the case with plot settings).

![image](https://user-images.githubusercontent.com/68477016/225372997-2a05470b-22de-4c72-9157-7059eda41db6.png)

Fixes the following issues as well:
- Change of y-scale was broken as it was looking for graphs.graphs.refresh instead of graphs.refresh
- Y_range was not accesabile in transformation tools due to a capitalization issue
- Canvas limits are refreshed now after every operation (so that the graph doesn't dissapear out of sight when nornalizing for instance)
- Centered data is now sorted as well (ran into some bugs otherwise iirc)
- Plot settings now properly refreshes when switching sample (it tried to call save_settings, but that function has been renamed on_close)
