### PR TITLE
Change wording in plot setings

### DIFF
--- a/data/ui/plot_settings.blp
+++ b/data/ui/plot_settings.blp
@@ -22,8 +22,8 @@ template PlotSettingsWindow : Adw.PreferencesWindow {
       description: _("Choose which data set to edit, the name of the data set and the axis positions");
 
       Adw.ComboRow datalist_chooser {
-        title: _("Data set ID");
-        subtitle: _("The data set to be edited");
+        title: _("Selected Item");
+        subtitle: _("Choose which item to edit");
         model: StringList {};
       }
 


### PR DESCRIPTION
Tiny PR. Changes the wording in the dropdown menu of Plot Settings from "Data set ID" with subtitle "The data set to be edited" to "Selected Item" and "Choose which item to edit".

I'm happy for other suggestions, but the original wording is not exactly human friendly language, it kinda originated from the fact that most data that I open in Graphs are measurements from samples I've made in my PhD. All those samples have a specific ID which is usually the same as the filename. Which explains some other wordings I've been using internally ("Sample" for data for instance at times) in the beginning. 

![image](https://user-images.githubusercontent.com/68477016/225585474-26506672-a814-468c-abc9-abf7ad831aca.png)
