### PR TITLE
Add support for xrdml files

### DIFF
--- a/src/graphs.py
+++ b/src/graphs.py
@@ -37,7 +37,7 @@ def open_files(self, files, import_settings):
                 toast = "Could not open data, wrong filetype"
                 self.main_window.add_toast(toast)
                 break
-    self.canvas.set_limits()
+    reload(self)
 
 
 def open_project(self, file):

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -122,4 +122,4 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         plot_settings.legend = self.plot_legend_check.get_active()
         plot_settings.plot_style = \
             self.plot_style.get_selected_item().get_string()
-        graphs.refresh(parent)
+        graphs.reload(parent)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -158,8 +158,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.plot_selected_marker_size.set_range(0, 30)
         self.plot_unselected_marker_size.set_range(0, 30)
         self.addequation_equation.set_text(str(config["addequation_equation"]))
-        self.addequation_x_start.set_text(str(config["addequation_X_start"]))
-        self.addequation_x_stop.set_text(str(config["addequation_X_stop"]))
+        self.addequation_x_start.set_text(str(config["addequation_x_start"]))
+        self.addequation_x_stop.set_text(str(config["addequation_x_stop"]))
         self.addequation_step_size.set_text(
             str(config["addequation_step_size"]))
         self.import_skip_rows.set_value(int(config["import_skip_rows"]))
@@ -178,8 +178,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.plot_major_tick_width.set_value(config["plot_major_tick_width"])
         self.plot_minor_tick_length.set_value(config["plot_minor_tick_length"])
         self.plot_major_tick_length.set_value(config["plot_major_tick_length"])
-        self.plot_y_label.set_text(config["plot_Y_label"])
-        self.plot_x_label.set_text(config["plot_X_label"])
+        self.plot_y_label.set_text(config["plot_y_label"])
+        self.plot_x_label.set_text(config["plot_x_label"])
         self.plot_right_label.set_text(config["plot_right_label"])
         self.plot_top_label.set_text(config["plot_top_label"])
         self.plot_title.set_text(config["plot_title"])
@@ -188,17 +188,17 @@ class PreferencesWindow(Adw.PreferencesWindow):
         utilities.set_chooser(
             self.center_data_chooser, config["action_center_data"])
         utilities.set_chooser(
-            self.plot_x_scale, config["plot_X_scale"])
+            self.plot_x_scale, config["plot_x_scale"])
         utilities.set_chooser(
             self.plot_top_scale, config["plot_top_scale"])
         utilities.set_chooser(
             self.plot_right_scale, config["plot_right_scale"])
         utilities.set_chooser(
-            self.plot_y_scale, config["plot_Y_scale"])
+            self.plot_y_scale, config["plot_y_scale"])
         utilities.set_chooser(
-            self.plot_x_position, config["plot_X_position"])
+            self.plot_x_position, config["plot_x_position"])
         utilities.set_chooser(
-            self.plot_y_position, config["plot_Y_position"])
+            self.plot_y_position, config["plot_y_position"])
         utilities.set_chooser(
             self.plot_tick_direction, config["plot_tick_direction"])
         utilities.set_chooser(
@@ -275,8 +275,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         font_weight = self.get_font_weight(font_name)
         font_style = self.get_font_style(font_name)
         config["addequation_equation"] = self.addequation_equation.get_text()
-        config["addequation_X_start"] = self.addequation_x_start.get_text()
-        config["addequation_X_stop"] = self.addequation_x_stop.get_text()
+        config["addequation_x_start"] = self.addequation_x_start.get_text()
+        config["addequation_x_stop"] = self.addequation_x_stop.get_text()
         config["addequation_step_size"] = self.addequation_step_size.get_text()
         config["plot_font_string"] = \
             self.plot_font_chooser.get_font_desc().to_string()
@@ -310,8 +310,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["plot_legend"] = self.plot_legend_check.get_active()
         config["plot_invert_color_cycle_dark"] = \
             self.plot_invert_color_cycle_dark.get_active()
-        config["plot_Y_label"] = self.plot_y_label.get_text()
-        config["plot_X_label"] = self.plot_x_label.get_text()
+        config["plot_y_label"] = self.plot_y_label.get_text()
+        config["plot_x_label"] = self.plot_x_label.get_text()
         config["plot_right_label"] = self.plot_right_label.get_text()
         config["plot_top_label"] = self.plot_top_label.get_text()
         config["plot_font_size"] = font_size
@@ -324,9 +324,9 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["savefig_filetype"] = filetype.get_selected_item().get_string()
         config["plot_color_cycle"] = \
             self.plot_color_cycle.get_selected_item().get_string()
-        config["plot_X_scale"] = \
+        config["plot_x_scale"] = \
             self.plot_x_scale.get_selected_item().get_string()
-        config["plot_Y_scale"] = \
+        config["plot_y_scale"] = \
             self.plot_y_scale.get_selected_item().get_string()
         config["plot_top_scale"] = \
             self.plot_top_scale.get_selected_item().get_string()
@@ -336,9 +336,9 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.plot_right_scale.get_selected_item().get_string()
         config["plot_top_scale"] = \
             self.plot_top_scale.get_selected_item().get_string()
-        config["plot_X_position"] = \
+        config["plot_x_position"] = \
             self.plot_x_position.get_selected_item().get_string()
-        config["plot_Y_position"] = \
+        config["plot_y_position"] = \
             self.plot_y_position.get_selected_item().get_string()
         config["action_center_data"] = \
             self.center_data_chooser.get_selected_item().get_string()


### PR DESCRIPTION
Adds support for xrdml files. 

xrdml is the default filetype for X-ray diffraction measurements performed by diffractometers from Panalytical (one of the bigger players in this world). The reason I've added support for xrdml specifically is because our university uses Panalytical diffractometers (so a lot of my data is in xrdml), and the file format is "easy enough" to work with. (It's open in the sense that it's basically just a xml file)

Automatically converts intensity to counts per second and detects what kind of measurement is stored, and then gives appropriate labels and axis limits.

Also had to fix some remaining config names that still had a capital letter.

[Screencast from 2023-03-16 21-17-50.webm](https://user-images.githubusercontent.com/68477016/225743038-5ce3c186-75e4-4f49-8e5a-79ea00265b9e.webm)

