### PR TITLE
Remove aarch64 from workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       options: --privileged
     strategy:
       matrix:
-        arch: [x86_64, aarch64]
+        arch: [x86_64]
       # Don't fail the whole workflow if one architecture fails
       fail-fast: false
     steps:


### PR DESCRIPTION
As the aarch64 github workflow seems broken, there doesn't seem to be much use to it at the moment. It only makes every single commit fail, defeating the purpose a bit of having this workflow in the first place.

Until we figure out what is wrong with this workflow, and if it's something we can fix ourselves, I propose we just build against x86 in the Github commits, and build for aarch64 for the Flathub releases where it builds fine, see: https://github.com/flathub/se.sjoerd.Graphs/pull/6