### PR TITLE
Set limits automatically on more occasions

### DIFF
--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -111,4 +111,5 @@ class EditItemWindow(Adw.PreferencesWindow):
 
         self.parent.item_boxes[self.item.key].label.set_text(
             utilities.shorten_label(self.item.name))
-        graphs.refresh(self.parent, set_limits = True)
+        graphs.refresh(self.parent, set_limits=True)
+        

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -112,4 +112,3 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.parent.item_boxes[self.item.key].label.set_text(
             utilities.shorten_label(self.item.name))
         graphs.refresh(self.parent, set_limits=True)
-        

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -111,4 +111,4 @@ class EditItemWindow(Adw.PreferencesWindow):
 
         self.parent.item_boxes[self.item.key].label.set_text(
             utilities.shorten_label(self.item.name))
-        graphs.refresh(self.parent)
+        graphs.refresh(self.parent, set_limits = True)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -116,11 +116,11 @@ def delete_item(self, key, give_toast=False):
         self.main_window.add_toast(f"Deleted {name}")
     clipboard.reset(self)
     if self.datadict:
-        refresh(self)
+        refresh(self, set_limits = True)
         ui.enable_data_dependent_buttons(
             self, utilities.get_selected_keys(self))
     else:
-        reload(self)
+        reload(self, set_limits = True)
         self.main_window.no_data_label_box.set_visible(True)
         self.main_window.list_box.set_visible(False)
         ui.enable_data_dependent_buttons(self, False)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -116,11 +116,11 @@ def delete_item(self, key, give_toast=False):
         self.main_window.add_toast(f"Deleted {name}")
     clipboard.reset(self)
     if self.datadict:
-        refresh(self, set_limits = True)
+        refresh(self, set_limits=True)
         ui.enable_data_dependent_buttons(
             self, utilities.get_selected_keys(self))
     else:
-        reload(self, set_limits = True)
+        reload(self, set_limits=True)
         self.main_window.no_data_label_box.set_visible(True)
         self.main_window.list_box.set_visible(False)
         ui.enable_data_dependent_buttons(self, False)


### PR DESCRIPTION
Sets the limits when

- Deleting an item
- Changing an item (e.g. when changing the axis of one item)

The reason behind this is in the first case, if I have one item with axes going from 0 to 12, and another with the limit going from 0 to 4, and then delete that first axis. Then it should reset the limits to fit the graphs that are left instead of keeping it from 0 to 12.

In the second case, the use case if if I change the axis of one of the items. So if I set the x-axis for the top item to "top", then it should set the limits so that it fits nicely for both graphs.