### PR TITLE
Get failsafe style from template

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,7 @@ conf.set('VERSION', version)
 conf.set('HOMEPAGE_URL', homepage_url)
 
 if debug
-  conf.set('LOG_LEVEL', 'DEBUG')
+  conf.set('LOG_LEVEL', 'INFO')
 else
   conf.set('LOG_LEVEL', 'INFO')
 endif

--- a/meson.build
+++ b/meson.build
@@ -50,7 +50,7 @@ conf.set('VERSION', version)
 conf.set('HOMEPAGE_URL', homepage_url)
 
 if debug
-  conf.set('LOG_LEVEL', 'INFO')
+  conf.set('LOG_LEVEL', 'DEBUG')
 else
   conf.set('LOG_LEVEL', 'INFO')
 endif

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -100,11 +100,11 @@ class Canvas(FigureCanvas):
         left = pyplot.rcParams["ytick.left"]
         top = pyplot.rcParams["xtick.top"]
         right = pyplot.rcParams["ytick.right"]
+        if pyplot.rcParams["xtick.minor.visible"]:
+            ticks = "both"
+        else:
+            ticks = "major"
         for axis in [self.top_right_axis, self.axis]:
-            if pyplot.rcParams["xtick.minor.visible"]:
-                ticks = "both"
-            else:
-                ticks = "major"
             axis.tick_params(bottom=bottom, left=left, top=top,
                              right=right, which=ticks)
 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -24,11 +24,10 @@ class Canvas(FigureCanvas):
         except KeyError:
             template_config = self.parent.preferences.template
             if Adw.StyleManager.get_default().get_dark():
-                default_style = template_config["plot_style_dark"]
+                stylename = template_config["plot_style_dark"]
             else:
-                default_style = template_config["plot_style_light"]
-            system_styles = plot_styles.get_system_styles(self.parent)
-            style_path = system_styles[default_style]
+                stylename = template_config["plot_style_light"]
+            style_path = plot_styles.get_user_styles(self.parent)[stylename]
             self.parent.main_window.add_toast(f"Plot style {stylename}"
                                               " does not exist")
         pyplot.style.use(style_path)

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import time
 
-from gi.repository import Adw, Gtk, GLib
+from gi.repository import Adw
 
 from graphs import plotting_tools, utilities, plot_styles
 from graphs.rename import RenameWindow
@@ -20,7 +20,7 @@ class Canvas(FigureCanvas):
         available_styles = plot_styles.get_user_styles(self.parent)
         stylename = self.parent.plot_settings.plot_style
         try:
-            style_path = available_styles["a"]
+            style_path = available_styles[stylename]
         except KeyError:
             template_config = self.parent.preferences.template
             if Adw.StyleManager.get_default().get_dark():

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -20,13 +20,13 @@ class Canvas(FigureCanvas):
         available_styles = plot_styles.get_user_styles(self.parent)
         stylename = self.parent.plot_settings.plot_style
         try:
-            style_path = available_styles[stylename]
+            style_path = available_styles["a"]
         except KeyError:
+            template_config = self.parent.preferences.template
             if Adw.StyleManager.get_default().get_dark():
-                default_style = self.parent.preferences.template["plot_style_dark"]
+                default_style = template_config["plot_style_dark"]
             else:
-                default_style = \
-                           self.parent.preferences.template["plot_style_light"]
+                default_style = template_config["plot_style_light"]
             style_path = available_styles[default_style]
             self.parent.main_window.add_toast(f"Plot style {stylename}"
                                               " does not exist")

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import time
 
+from gi.repository import Adw, Gtk, GLib
+
 from graphs import plotting_tools, utilities, plot_styles
 from graphs.rename import RenameWindow
 
@@ -20,8 +22,14 @@ class Canvas(FigureCanvas):
         try:
             style_path = available_styles[stylename]
         except KeyError:
-            style_path = available_styles[next(iter(available_styles))]
-            self.parent.main_window.add_toast(f"{stylename} does not exist")
+            if Adw.StyleManager.get_default().get_dark():
+                default_style = self.parent.preferences.template["plot_style_dark"]
+            else:
+                default_style = \
+                           self.parent.preferences.template["plot_style_light"]
+            style_path = available_styles[default_style]
+            self.parent.main_window.add_toast(f"Plot style {stylename}"
+                                              " does not exist")
         pyplot.style.use(style_path)
         self.figure = Figure()
         self.figure.set_tight_layout(True)

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -100,12 +100,13 @@ class Canvas(FigureCanvas):
         left = pyplot.rcParams["ytick.left"]
         top = pyplot.rcParams["xtick.top"]
         right = pyplot.rcParams["ytick.right"]
-        minor = pyplot.rcParams["xtick.minor.visible"]
         for axis in [self.top_right_axis, self.axis]:
-            axis.tick_params(bottom=bottom, left=left, top=top, right=right)
-            if minor:
-                axis.tick_params(bottom=bottom, left=left, top=top,
-                                 right=right, which="minor")
+            if pyplot.rcParams["xtick.minor.visible"]:
+                ticks = "both"
+            else:
+                ticks = "major"
+            axis.tick_params(bottom=bottom, left=left, top=top,
+                                 right=right, which=ticks)
 
     # Overwritten function - do not change name
     def __call__(self, event):

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -27,7 +27,8 @@ class Canvas(FigureCanvas):
                 default_style = template_config["plot_style_dark"]
             else:
                 default_style = template_config["plot_style_light"]
-            style_path = available_styles[default_style]
+            system_styles = plot_styles.get_system_styles(self.parent)
+            style_path = system_styles[default_style]
             self.parent.main_window.add_toast(f"Plot style {stylename}"
                                               " does not exist")
         pyplot.style.use(style_path)

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -95,16 +95,16 @@ class Canvas(FigureCanvas):
         self.axis.set_xscale(plot_settings.xscale)
 
     def set_ticks(self):
-        bottom = pyplot.rcParams["xtick.bottom"] == "True"
-        left = pyplot.rcParams["ytick.left"] == "True"
-        top = pyplot.rcParams["xtick.top"] == "True"
-        right = pyplot.rcParams["ytick.right"] == "True"
-        minor = pyplot.rcParams["xtick.minor.visible"] == "True"
-        for axis in [self.top_right_axis,
-                     self.top_left_axis, self.axis, self.right_axis]:
+        bottom = pyplot.rcParams["xtick.bottom"]
+        left = pyplot.rcParams["ytick.left"]
+        top = pyplot.rcParams["xtick.top"]
+        right = pyplot.rcParams["ytick.right"]
+        minor = pyplot.rcParams["xtick.minor.visible"]
+        for axis in [self.top_right_axis, self.axis]:
             axis.tick_params(bottom=bottom, left=left, top=top, right=right)
             if minor:
-                axis.minorticks_on()
+                axis.tick_params(bottom=bottom, left=left, top=top,
+                                 right=right, which="minor")
 
     # Overwritten function - do not change name
     def __call__(self, event):

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -106,7 +106,7 @@ class Canvas(FigureCanvas):
             else:
                 ticks = "major"
             axis.tick_params(bottom=bottom, left=left, top=top,
-                                 right=right, which=ticks)
+                             right=right, which=ticks)
 
     # Overwritten function - do not change name
     def __call__(self, event):

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -19,8 +19,8 @@ class Preferences():
     def check_config(self, config):
         template_path = os.path.join(self.parent.modulepath, "config.json")
         with open(template_path, "r", encoding="utf-8") as file:
-            template = json.load(file)
-        if set(config.keys()) != set(template.keys()):
+            self.template = json.load(file)
+        if set(config.keys()) != set(self.template.keys()):
             config = utilities.remove_unused_config_keys(config, template)
             config = utilities.add_new_config_keys(config, template)
         return config

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import numpy
 
-
 def remove_unused_config_keys(config, template):
     delete_list = []
     for key in config.keys():
@@ -18,9 +17,11 @@ def remove_unused_config_keys(config, template):
 
 def sig_fig_round(number, digits):
     """Round a number to the specified number of significant digits."""
-    if number is None:
+    try:
+        # Convert to scientific notation, and get power
+        power = "{:e}".format(float(number)).split("e")[1]
+    except IndexError:
         return None
-    power = "{:e}".format(float(number)).split("e")[1]
     return round(float(number), -(int(power) - digits + 1))
 
 


### PR DESCRIPTION
Gets the fail safe style from template instead of using the first available option. The reason for this is that this ensures that the dark style will be loaded in dark mode, and the light style will be loaded in light mode. And the template should always, always work. Also avoids unexpected theming if the top style is something custom that does not fit with the general style of the UI.

When people upgrade to version 1.5, the old style will no longer work so this exception will be triggered. By default it selects the top style in the current main branch, which is adwaita-dark. Giving a weird experience for people using light theme. Hard-coding adwaita will have the same issue, but for people using dark theme. This PR solves this.