### PR TITLE
Small changes

### DIFF
--- a/data/styles/adwaita-dark.mplstyle
+++ b/data/styles/adwaita-dark.mplstyle
@@ -89,8 +89,8 @@ axes.facecolor: 242424
 figure.facecolor: 242424
 figure.edgecolor: 242424
 
-axes.prop_cycle: cycler('color', ['4C72B0', '55A868', 'C44E52', '8172B2', 'CCB974', '64B5CD'])
-patch.facecolor: 4C72B0
+axes.prop_cycle: cycler('color', ['1A5FB4', '26A269', 'E5A50A', 'C64600', 'A51D2D', '613583', '63452C', '9A9996'])
+patch.facecolor: 1A5FB4
 
 # other
 axes.linewidth: 0.8

--- a/data/styles/adwaita-dark.mplstyle
+++ b/data/styles/adwaita-dark.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: FFFFFF
 axes.labelcolor: FFFFFF
+xtick.labelcolor: FFFFFF
+ytick.labelcolor: FFFFFF
 xtick.color: FFFFFF
 ytick.color: FFFFFF
 axes.edgecolor: FFFFFF

--- a/data/styles/adwaita-dark.mplstyle
+++ b/data/styles/adwaita-dark.mplstyle
@@ -102,10 +102,7 @@ legend.frameon: True
 
 # custom
 patch.linewidth: 1
-
 figure.figsize: 8.0, 15.5
-
 image.cmap: Greys
-
 legend.numpoints: 1
 legend.scatterpoints: 1

--- a/data/styles/adwaita.mplstyle
+++ b/data/styles/adwaita.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 000000
 axes.labelcolor: 000000
+xtick.labelcolor: 000000
+ytick.labelcolor: 000000
 xtick.color: 000000
 ytick.color: 000000
 axes.edgecolor: 000000

--- a/data/styles/adwaita.mplstyle
+++ b/data/styles/adwaita.mplstyle
@@ -89,8 +89,8 @@ axes.facecolor: FFFFFF
 figure.facecolor: FAFAFA
 figure.edgecolor: FAFAFA
 
-axes.prop_cycle: cycler('color', ['4C72B0', '55A868', 'C44E52', '8172B2', 'CCB974', '64B5CD'])
-patch.facecolor: 4C72B0
+axes.prop_cycle: cycler('color', ['1A5FB4', '26A269', 'E5A50A', 'C64600', 'A51D2D', '613583', '63452C', '9A9996'])
+patch.facecolor: 1A5FB4
 
 # other
 axes.linewidth: 0.8

--- a/data/styles/bmh.mplstyle
+++ b/data/styles/bmh.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: BCBCBC

--- a/data/styles/classic.mplstyle
+++ b/data/styles/classic.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 000000
 axes.labelcolor: 000000
+xtick.labelcolor: 000000
+ytick.labelcolor: 000000
 xtick.color: 000000
 ytick.color: 000000
 axes.edgecolor: 000000

--- a/data/styles/dark-background.mplstyle
+++ b/data/styles/dark-background.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: FFFFFF
 axes.labelcolor: FFFFFF
+xtick.labelcolor: FFFFFF
+ytick.labelcolor: FFFFFF
 xtick.color: FFFFFF
 ytick.color: FFFFFF
 axes.edgecolor: FFFFFF

--- a/data/styles/fivethirtyeight.mplstyle
+++ b/data/styles/fivethirtyeight.mplstyle
@@ -102,7 +102,6 @@ legend.frameon: True
 
 # custom
 axes.labelsize: large
-axes.axisbelow: true
 patch.edgecolor: f0f0f0
 patch.linewidth: 0.5
 svg.fonttype: path

--- a/data/styles/fivethirtyeight.mplstyle
+++ b/data/styles/fivethirtyeight.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: F0F0F0

--- a/data/styles/ggplot.mplstyle
+++ b/data/styles/ggplot.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 555555
 axes.labelcolor: 555555
+xtick.labelcolor: 555555
+ytick.labelcolor: 555555
 xtick.color: 555555
 ytick.color: 555555
 axes.edgecolor: FFFFFF

--- a/data/styles/grayscale.mplstyle
+++ b/data/styles/grayscale.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 000000
 axes.labelcolor: 000000
+xtick.labelcolor: 000000
+ytick.labelcolor: 000000
 xtick.color: 000000
 ytick.color: 000000
 axes.edgecolor: 000000

--- a/data/styles/grayscale.mplstyle
+++ b/data/styles/grayscale.mplstyle
@@ -89,8 +89,8 @@ axes.facecolor: FFFFFF
 figure.facecolor: BFBFBF
 figure.edgecolor: BFBFBF
 
-axes.prop_cycle: cycler('color', ['0.00', '0.40', '0.60', '0.70'])
-patch.facecolor: gray
+axes.prop_cycle: cycler('color', ['000000', '666666', '999999', 'B3B3B3'])
+patch.facecolor: 000000
 
 # other
 axes.linewidth: 1

--- a/data/styles/seaborn-bright.mplstyle
+++ b/data/styles/seaborn-bright.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-colorblind.mplstyle
+++ b/data/styles/seaborn-colorblind.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-dark-palette.mplstyle
+++ b/data/styles/seaborn-dark-palette.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-dark.mplstyle
+++ b/data/styles/seaborn-dark.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-darkgrid.mplstyle
+++ b/data/styles/seaborn-darkgrid.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-deep.mplstyle
+++ b/data/styles/seaborn-deep.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-muted.mplstyle
+++ b/data/styles/seaborn-muted.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-notebook.mplstyle
+++ b/data/styles/seaborn-notebook.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-paper.mplstyle
+++ b/data/styles/seaborn-paper.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-pastel.mplstyle
+++ b/data/styles/seaborn-pastel.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-poster.mplstyle
+++ b/data/styles/seaborn-poster.mplstyle
@@ -82,6 +82,8 @@ axes.titlepad: 18
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-talk.mplstyle
+++ b/data/styles/seaborn-talk.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 20
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/seaborn-ticks.mplstyle
+++ b/data/styles/seaborn-ticks.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: 262626

--- a/data/styles/seaborn-white.mplstyle
+++ b/data/styles/seaborn-white.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: 262626

--- a/data/styles/seaborn-whitegrid.mplstyle
+++ b/data/styles/seaborn-whitegrid.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: CCCCCC

--- a/data/styles/seaborn.mplstyle
+++ b/data/styles/seaborn.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/data/styles/solarized-light.mplstyle
+++ b/data/styles/solarized-light.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 657B83
 axes.labelcolor: 657B83
+xtick.labelcolor: 657B83
+ytick.labelcolor: 657B83
 xtick.color: 657B83
 ytick.color: 657B83
 axes.edgecolor: EEE8D5

--- a/data/styles/tableau-colorblind10.mplstyle
+++ b/data/styles/tableau-colorblind10.mplstyle
@@ -79,6 +79,8 @@ axes.titlepad: 15
 # colors
 text.color: 262626
 axes.labelcolor: 262626
+xtick.labelcolor: 262626
+ytick.labelcolor: 262626
 xtick.color: 262626
 ytick.color: 262626
 axes.edgecolor: FFFFFF

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -296,6 +296,8 @@ class PlotStylesWindow(Adw.Window):
         # colors
         style["text.color"] = self.text_color.color
         style["axes.labelcolor"] = self.text_color.color
+        style["xtick.labelcolor"] = self.text_color.color
+        style["ytick.labelcolor"] = self.text_color.color
         style["xtick.color"] = self.tick_color.color
         style["ytick.color"] = self.tick_color.color
         style["axes.edgecolor"] = self.axis_color.color

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -313,6 +313,7 @@ class PlotStylesWindow(Adw.Window):
             self.line_colors_box.remove(list_box)
             del self.color_boxes[color_box]
         style["axes.prop_cycle"] = cycler(color=line_colors)
+        style["patch.facecolor"] = line_colors[0]
 
         # other
         style["axes.linewidth"] = self.axis_width.get_value()


### PR DESCRIPTION
- apply textcolor for tick.labelcolor. This allows having the ticks in a different color than their labels
- Use hex notation for grayscale color cycle
- Set patch color as first line color (all styles already behave this way)
- Tweak default adwaita color cycle