### PR TITLE
Properly remove item from item_menu when deleting an item

### DIFF
--- a/src/graphs.py
+++ b/src/graphs.py
@@ -108,6 +108,7 @@ def add_item(self, item, reset_clipboard=True):
 
 def delete_item(self, key, give_toast=False):
     self.main_window.list_box.remove(self.item_menu[key])
+    self.item_menu.pop(key)
     name = self.datadict[key].name
     del self.datadict[key]
     if give_toast:


### PR DESCRIPTION
This fixes a bug where Graphs would crash when changing the order of an item (with drag and drop) just after deleting an item.

The error otherwise happens without error output or warning, kinda drove me crazy for while hunting the bug down. Wasn't even sure what triggered it, just noticed it crashed sometimes.